### PR TITLE
Add support for nested tuple arrays and fixed arrays

### DIFF
--- a/ethabi/src/param.rs
+++ b/ethabi/src/param.rs
@@ -235,4 +235,49 @@ mod tests {
 			}
 		);
 	}
+
+	#[test]
+	fn param_tuple_with_nested_tuple_arrays_deserialization() {
+		let s = r#"{
+			"name": "foo",
+			"type": "tuple",
+			"components": [
+				{
+					"name": "bar",
+					"type": "tuple[]",
+					"components": [
+						{
+							"name": "a",
+							"type": "address"
+						}
+					]
+				},
+				{
+					"name": "baz",
+					"type": "tuple[42]",
+					"components": [
+						{
+							"name": "b",
+							"type": "address"
+						}
+					]
+				}
+			]
+		}"#;
+
+		let deserialized: Param = serde_json::from_str(s).unwrap();
+
+		assert_eq!(
+			deserialized,
+			Param {
+				name: "foo".to_owned(),
+				kind: ParamType::Tuple(vec![
+					Box::new(ParamType::Array(Box::new(ParamType::Tuple(vec![Box::new(ParamType::Address)])))),
+					Box::new(
+						ParamType::FixedArray(Box::new(ParamType::Tuple(vec![Box::new(ParamType::Address)])), 42,)
+					),
+				]),
+			}
+		);
+	}
 }

--- a/ethabi/src/tuple_param.rs
+++ b/ethabi/src/tuple_param.rs
@@ -74,13 +74,33 @@ impl<'a> Visitor<'a> for TupleParamVisitor {
 			}
 		}
 
-		let kind = kind.ok_or_else(|| Error::missing_field("kind")).and_then(|param_type| {
-			if let ParamType::Tuple(_) = param_type {
+		let kind = kind.ok_or_else(|| Error::missing_field("kind")).and_then(|param_type| match param_type {
+			ParamType::Tuple(_) => {
 				let tuple_params = components.ok_or_else(|| Error::missing_field("components"))?;
 				Ok(ParamType::Tuple(tuple_params.into_iter().map(|param| param.kind).map(Box::new).collect()))
-			} else {
-				Ok(param_type)
 			}
+			ParamType::Array(inner_param_type) => match *inner_param_type {
+				ParamType::Tuple(_) => {
+					let tuple_params = components.ok_or_else(|| Error::missing_field("components"))?;
+					Ok(ParamType::Array(Box::new(ParamType::Tuple(
+						tuple_params.into_iter().map(|param| param.kind).map(Box::new).collect(),
+					))))
+				}
+				_ => Ok(ParamType::Array(inner_param_type)),
+			},
+			ParamType::FixedArray(inner_param_type, size) => match *inner_param_type {
+				ParamType::Tuple(_) => {
+					let tuple_params = components.ok_or_else(|| Error::missing_field("components"))?;
+					Ok(ParamType::FixedArray(
+						Box::new(ParamType::Tuple(
+							tuple_params.into_iter().map(|param| param.kind).map(Box::new).collect(),
+						)),
+						size,
+					))
+				}
+				_ => Ok(ParamType::FixedArray(inner_param_type, size)),
+			},
+			_ => Ok(param_type),
 		})?;
 
 		Ok(TupleParam { name, kind })


### PR DESCRIPTION
The `ethabi` crate currently does not support tuples with nested tuple arrays and fixed arrays of the form
```solidity
struct Bar {
    address a;
}
struct Foo {
    Bar[] bar;
    Bar[2] bar_fixed;
}
```

This PR adds support for it. There is a bit of duplicated logic between `TupleParam` and `Param` deserialization code, but I didn't address that here.

### Test Plan

Added a new unit test for testing nested tuple types.