### PR TITLE
Support the receive function as an additional operation type

### DIFF
--- a/derive/src/contract.rs
+++ b/derive/src/contract.rs
@@ -77,6 +77,7 @@ mod test {
 			constructor: None,
 			functions: Default::default(),
 			events: Default::default(),
+			receive: false,
 			fallback: false,
 		};
 

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -117,6 +117,11 @@ impl Contract {
 	pub fn events(&self) -> Events {
 		Events(self.events.values().flatten())
 	}
+
+	/// Returns true if contract has fallback
+	pub fn fallback(&self) -> bool {
+		self.fallback
+	}
 }
 
 /// Contract functions iterator.

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -17,7 +17,7 @@ use std::iter::Flatten;
 use std::{fmt, io};
 
 /// API building calls to contracts ABI.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Contract {
 	/// Contract constructor.
 	pub constructor: Option<Constructor>,
@@ -50,13 +50,7 @@ impl<'a> Visitor<'a> for ContractVisitor {
 	}
 
 	fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error> where A: SeqAccess<'a> {
-		let mut result = Contract {
-			constructor: None,
-			functions: HashMap::default(),
-			events: HashMap::default(),
-			receive: true,
-			fallback: false,
-		};
+		let mut result = Contract::default();
 
 		while let Some(operation) = seq.next_element()? {
 			match operation {

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -25,6 +25,8 @@ pub struct Contract {
 	pub functions: HashMap<String, Vec<Function>>,
 	/// Contract events, maps signature to event.
 	pub events: HashMap<String, Vec<Event>>,
+	/// Contract has receive function.
+	pub receive: bool,
 	/// Contract has fallback function.
 	pub fallback: bool,
 }
@@ -47,12 +49,14 @@ impl<'a> Visitor<'a> for ContractVisitor {
 		formatter.write_str("valid abi spec file")
 	}
 
-	fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-	where
-		A: SeqAccess<'a>,
-	{
-		let mut result =
-			Contract { constructor: None, functions: HashMap::default(), events: HashMap::default(), fallback: false };
+	fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error> where A: SeqAccess<'a> {
+		let mut result = Contract {
+			constructor: None,
+			functions: HashMap::default(),
+			events: HashMap::default(),
+			receive: true,
+			fallback: false,
+		};
 
 		while let Some(operation) = seq.next_element()? {
 			match operation {
@@ -67,7 +71,10 @@ impl<'a> Visitor<'a> for ContractVisitor {
 				}
 				Operation::Fallback => {
 					result.fallback = true;
-				}
+				},
+				Operation::Receive => {
+					result.receive = true;
+				},
 			}
 		}
 
@@ -115,11 +122,6 @@ impl Contract {
 	/// Iterate over all events of the contract in arbitrary order.
 	pub fn events(&self) -> Events {
 		Events(self.events.values().flatten())
-	}
-
-	/// Returns true if contract has fallback
-	pub fn fallback(&self) -> bool {
-		self.fallback
 	}
 }
 

--- a/ethabi/src/operation.rs
+++ b/ethabi/src/operation.rs
@@ -25,6 +25,7 @@ pub enum Operation {
 	Event(Event),
 	/// Fallback, ignored.
 	Fallback,
+	Receive,
 }
 
 impl<'a> Deserialize<'a> for Operation {
@@ -55,7 +56,8 @@ impl<'a> Deserialize<'a> for Operation {
 				Operation::Event(e)
 			}),
 			"fallback" => Ok(Operation::Fallback),
-			_ => Err(SerdeError::custom("Invalid operation type.")),
+			"receive" => Ok(Operation::Receive),
+			other => Err(SerdeError::custom(format!("Invalid operation type {}.", other))),
 		};
 		result.map_err(|e| D::Error::custom(e.to_string()))
 	}


### PR DESCRIPTION
In the Solidity 0.6.0 release the unnamed function, previously `fallback`, has been split into two functions, `receive` and `fallback`.   ([0.6.0 breaking changes](https://solidity.readthedocs.io/en/v0.6.0/060-breaking-changes.html))

This PR adds support for the `receive` function. 