### PR TITLE
Fix compiler and clippy warnings

### DIFF
--- a/derive/src/function.rs
+++ b/derive/src/function.rs
@@ -222,6 +222,7 @@ mod tests {
 
 	#[test]
 	fn test_no_params() {
+		#[allow(deprecated)]
 		let ethabi_function = ethabi::Function {
 			name: "empty".into(),
 			inputs: vec![],
@@ -285,6 +286,7 @@ mod tests {
 
 	#[test]
 	fn test_one_param() {
+		#[allow(deprecated)]
 		let ethabi_function = ethabi::Function {
 			name: "hello".into(),
 			inputs: vec![ethabi::Param { name: "foo".into(), kind: ethabi::ParamType::Address }],
@@ -354,6 +356,7 @@ mod tests {
 
 	#[test]
 	fn test_multiple_params() {
+		#[allow(deprecated)]
 		let ethabi_function = ethabi::Function {
 			name: "multi".into(),
 			inputs: vec![

--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -64,7 +64,7 @@ pub fn decode(types: &[ParamType], data: &[u8]) -> Result<Vec<Token>, Error> {
 
 fn peek(data: &[u8], offset: usize, len: usize) -> Result<&[u8], Error> {
 	if offset + len > data.len() {
-		return Err(Error::InvalidData);
+		Err(Error::InvalidData)
 	} else {
 		Ok(&data[offset..(offset + len)])
 	}
@@ -80,7 +80,7 @@ fn peek_32_bytes(data: &[u8], offset: usize) -> Result<Word, Error> {
 
 fn take_bytes(data: &[u8], offset: usize, len: usize) -> Result<Vec<u8>, Error> {
 	if offset + len > data.len() {
-		return Err(Error::InvalidData);
+		Err(Error::InvalidData)
 	} else {
 		Ok((&data[offset..(offset + len)]).to_vec())
 	}

--- a/ethabi/src/filter.rs
+++ b/ethabi/src/filter.rs
@@ -104,9 +104,9 @@ impl<T> From<Vec<T>> for Topic<T> {
 	}
 }
 
-impl<T> Into<Vec<T>> for Topic<T> {
-	fn into(self) -> Vec<T> {
-		match self {
+impl<T> From<Topic<T>> for Vec<T> {
+	fn from(topic: Topic<T>) -> Self {
+		match topic {
 			Topic::Any => vec![],
 			Topic::This(topic) => vec![topic],
 			Topic::OneOf(topics) => topics,

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -95,6 +95,7 @@ mod tests {
 
 	#[test]
 	fn test_function_encode_call() {
+		#[allow(deprecated)]
 		let func = Function {
 			name: "baz".to_owned(),
 			inputs: vec![

--- a/ethabi/src/operation.rs
+++ b/ethabi/src/operation.rs
@@ -65,7 +65,6 @@ impl<'a> Deserialize<'a> for Operation {
 mod tests {
 	use super::Operation;
 	use crate::{Event, EventParam, Function, Param, ParamType, StateMutability};
-	use serde_json;
 
 	#[test]
 	fn deserialize_operation() {
@@ -81,16 +80,15 @@ mod tests {
 
 		let deserialized: Operation = serde_json::from_str(s).unwrap();
 
-		assert_eq!(
-			deserialized,
-			Operation::Function(Function {
-				name: "foo".to_owned(),
-				inputs: vec![Param { name: "a".to_owned(), kind: ParamType::Address }],
-				outputs: vec![],
-				constant: false,
-				state_mutability: StateMutability::NonPayable,
-			})
-		);
+		#[allow(deprecated)]
+		let function = Function {
+			name: "foo".to_owned(),
+			inputs: vec![Param { name: "a".to_owned(), kind: ParamType::Address }],
+			outputs: vec![],
+			constant: false,
+			state_mutability: StateMutability::NonPayable,
+		};
+		assert_eq!(deserialized, Operation::Function(function));
 	}
 
 	#[test]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -21,9 +21,9 @@ mod tests {
 
 	struct Wrapper([u8; 20]);
 
-	impl Into<Address> for Wrapper {
-		fn into(self) -> Address {
-			self.0.into()
+	impl From<Wrapper> for Address {
+		fn from(wrapper: Wrapper) -> Self {
+			wrapper.0.into()
 		}
 	}
 


### PR DESCRIPTION
No logic change. Fixed all warnings from `cargo clippy --all-targets`.