### PR TITLE
Update dependencies

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,7 +18,7 @@ ethabi = { version = "13.0.0", path = "../ethabi" }
 hex = "0.4"
 sha3 = "0.9"
 structopt = "0.3"
-itertools = "0.9"
+itertools = "0.10"
 
 [[bin]]
 name = "ethabi"

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha3 = "0.9"
-ethereum-types = "0.10.0"
+ethereum-types = "0.11.0"
 thiserror = "1"
 uint = "0.9.0"
 


### PR DESCRIPTION
Based on output of `cargo outdated --root-deps-only`.