### PR TITLE
Serialize contracts

### DIFF
--- a/ethabi/src/constructor.rs
+++ b/ethabi/src/constructor.rs
@@ -8,10 +8,10 @@
 
 //! Contract constructor call builder.
 use crate::{encode, Bytes, Error, Param, ParamType, Result, Token};
-use serde::Deserialize;
+use serde::{Serialize, Deserialize};
 
 /// Contract constructor specification.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Constructor {
 	/// Constructor input.
 	pub inputs: Vec<Param>,

--- a/ethabi/src/constructor.rs
+++ b/ethabi/src/constructor.rs
@@ -8,7 +8,7 @@
 
 //! Contract constructor call builder.
 use crate::{encode, Bytes, Error, Param, ParamType, Result, Token};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Contract constructor specification.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -7,9 +7,9 @@
 // except according to those terms.
 
 use crate::{errors, operation::Operation, Constructor, Error, Event, Function};
-use serde::ser::SerializeSeq;
 use serde::{
 	de::{SeqAccess, Visitor},
+	ser::SerializeSeq,
 	Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::{
@@ -203,10 +203,8 @@ impl<'a> Iterator for Events<'a> {
 #[cfg(test)]
 #[allow(deprecated)]
 mod test {
-	use crate::tests::assert_ser_de;
-	use crate::{Constructor, Contract, Event, EventParam, Function, Param, ParamType};
-	use std::collections::HashMap;
-	use std::iter::FromIterator;
+	use crate::{tests::assert_ser_de, Constructor, Contract, Event, EventParam, Function, Param, ParamType};
+	use std::{collections::HashMap, iter::FromIterator};
 
 	#[test]
 	fn empty() {

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -201,6 +201,7 @@ impl<'a> Iterator for Events<'a> {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod test {
 	use crate::tests::assert_ser_de;
 	use crate::{Constructor, Contract, Event, EventParam, Function, Param, ParamType};

--- a/ethabi/src/event.rs
+++ b/ethabi/src/event.rs
@@ -21,7 +21,7 @@ use crate::{
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Event {
 	/// Event name.
-	#[serde(deserialize_with = "crate::function::sanitize_name::deserialize")]
+	#[serde(deserialize_with = "crate::util::sanitize_name::deserialize")]
 	pub name: String,
 	/// Event input.
 	pub inputs: Vec<EventParam>,

--- a/ethabi/src/event.rs
+++ b/ethabi/src/event.rs
@@ -8,7 +8,7 @@
 
 //! Contract event.
 
-use serde::Deserialize;
+use serde::{Serialize, Deserialize};
 use sha3::{Digest, Keccak256};
 use std::collections::HashMap;
 
@@ -18,9 +18,10 @@ use crate::{
 };
 
 /// Contract event.
-#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Event {
 	/// Event name.
+	#[serde(deserialize_with = "crate::function::sanitize_name::deserialize")]
 	pub name: String,
 	/// Event input.
 	pub inputs: Vec<EventParam>,

--- a/ethabi/src/event.rs
+++ b/ethabi/src/event.rs
@@ -8,7 +8,7 @@
 
 //! Contract event.
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use std::collections::HashMap;
 

--- a/ethabi/src/event_param.rs
+++ b/ethabi/src/event_param.rs
@@ -8,10 +8,12 @@
 
 //! Event param specification.
 
+use crate::param_type::Writer;
 use crate::{ParamType, TupleParam};
+use serde::ser::SerializeMap;
 use serde::{
 	de::{Error, MapAccess, Visitor},
-	Deserialize, Deserializer,
+	Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::fmt;
 
@@ -88,6 +90,23 @@ impl<'a> Visitor<'a> for EventParamVisitor {
 		crate::param::set_tuple_components(&mut kind, components)?;
 		let indexed = indexed.unwrap_or(false);
 		Ok(EventParam { name, kind, indexed })
+	}
+}
+
+impl Serialize for EventParam {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let mut map = serializer.serialize_map(None)?;
+		map.serialize_entry("name", &self.name)?;
+		map.serialize_entry("type", &Writer::write_for_abi(&self.kind, false))?;
+		map.serialize_entry("indexed", &self.indexed)?;
+		if let Some(inner_tuple) = crate::param::inner_tuple(&self.kind) {
+			map.serialize_key("components")?;
+			map.serialize_value(&crate::param::SerializeableParamVec(inner_tuple))?;
+		}
+		map.end()
 	}
 }
 

--- a/ethabi/src/event_param.rs
+++ b/ethabi/src/event_param.rs
@@ -8,11 +8,10 @@
 
 //! Event param specification.
 
-use crate::param_type::Writer;
-use crate::{ParamType, TupleParam};
-use serde::ser::SerializeMap;
+use crate::{param_type::Writer, ParamType, TupleParam};
 use serde::{
 	de::{Error, MapAccess, Visitor},
+	ser::SerializeMap,
 	Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::fmt;
@@ -112,8 +111,7 @@ impl Serialize for EventParam {
 
 #[cfg(test)]
 mod tests {
-	use crate::tests::assert_json_eq;
-	use crate::{EventParam, ParamType};
+	use crate::{tests::assert_json_eq, EventParam, ParamType};
 
 	#[test]
 	fn event_param_deserialization() {

--- a/ethabi/src/event_param.rs
+++ b/ethabi/src/event_param.rs
@@ -113,6 +113,7 @@ impl Serialize for EventParam {
 #[cfg(test)]
 mod tests {
 	use crate::{EventParam, ParamType};
+	use crate::tests::assert_json_eq;
 
 	#[test]
 	fn event_param_deserialization() {
@@ -125,6 +126,8 @@ mod tests {
 		let deserialized: EventParam = serde_json::from_str(s).unwrap();
 
 		assert_eq!(deserialized, EventParam { name: "foo".to_owned(), kind: ParamType::Address, indexed: true });
+
+		assert_json_eq(s, serde_json::to_string(&deserialized).unwrap().as_str());
 	}
 
 	#[test]
@@ -135,15 +138,12 @@ mod tests {
 			"indexed": true,
 			"components": [
 				{
-					"name": "amount",
 					"type": "uint48"
 				},
 				{
-					"name": "things",
 					"type": "tuple",
 					"components": [
 						{
-							"name": "baseTupleParam",
 							"type": "address"
 						}
 					]
@@ -161,6 +161,8 @@ mod tests {
 				indexed: true,
 			}
 		);
+
+		assert_json_eq(s, serde_json::to_string(&deserialized).unwrap().as_str());
 	}
 
 	#[test]
@@ -225,5 +227,7 @@ mod tests {
 				indexed: false,
 			}
 		);
+
+		assert_json_eq(s, serde_json::to_string(&deserialized).unwrap().as_str());
 	}
 }

--- a/ethabi/src/event_param.rs
+++ b/ethabi/src/event_param.rs
@@ -112,8 +112,8 @@ impl Serialize for EventParam {
 
 #[cfg(test)]
 mod tests {
-	use crate::{EventParam, ParamType};
 	use crate::tests::assert_json_eq;
+	use crate::{EventParam, ParamType};
 
 	#[test]
 	fn event_param_deserialization() {

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Function {
 	/// Function name.
-	#[serde(deserialize_with = "crate::function::sanitize_name::deserialize")]
+	#[serde(deserialize_with = "crate::util::sanitize_name::deserialize")]
 	pub name: String,
 	/// Function input.
 	pub inputs: Vec<Param>,
@@ -85,26 +85,6 @@ impl Function {
 		match (inputs.len(), outputs.len()) {
 			(_, 0) => format!("{}({})", self.name, inputs),
 			(_, _) => format!("{}({}):({})", self.name, inputs, outputs),
-		}
-	}
-}
-
-// This is a workaround to support non-spec compliant function and event names,
-// see: https://github.com/paritytech/parity/issues/4122
-pub(crate) mod sanitize_name {
-	use serde::{Deserializer, Deserialize};
-
-	pub fn deserialize<'de, D>(deserializer: D) -> Result<String, D::Error>
-		where D: Deserializer<'de>
-	{
-		let mut name = String::deserialize(deserializer)?;
-		sanitize_name(&mut name);
-		Ok(name)
-	}
-
-	fn sanitize_name(name: &mut String) {
-		if let Some(i) = name.find('(') {
-			name.truncate(i);
 		}
 	}
 }

--- a/ethabi/src/operation.rs
+++ b/ethabi/src/operation.rs
@@ -9,56 +9,27 @@
 //! Operation type.
 
 use crate::{Constructor, Event, Function};
-use serde::{de::Error as SerdeError, Deserialize, Deserializer};
-use serde_json::{value::from_value, Value};
+use serde::{Deserialize, Serialize};
 
 /// Operation type.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
 pub enum Operation {
 	/// Contract constructor.
+	#[serde(rename = "constructor")]
 	Constructor(Constructor),
 	/// Contract function.
+	#[serde(rename = "function")]
 	Function(Function),
 	/// Contract event.
+	#[serde(rename = "event")]
 	Event(Event),
-	/// Fallback, ignored.
+	/// Fallback function.
+	#[serde(rename = "fallback")]
 	Fallback,
+	/// Receive function.
+	#[serde(rename = "receive")]
 	Receive,
-}
-
-impl<'a> Deserialize<'a> for Operation {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: Deserializer<'a>,
-	{
-		let v: Value = Deserialize::deserialize(deserializer)?;
-		let map = v.as_object().ok_or_else(|| SerdeError::custom("Invalid operation"))?;
-		let s = map.get("type").and_then(Value::as_str).ok_or_else(|| SerdeError::custom("Invalid operation type"))?;
-
-		// This is a workaround to support non-spec compliant function and event names,
-		// see: https://github.com/paritytech/parity/issues/4122
-		fn sanitize_name(name: &mut String) {
-			if let Some(i) = name.find('(') {
-				name.truncate(i);
-			}
-		}
-
-		let result = match s {
-			"constructor" => from_value(v).map(Operation::Constructor),
-			"function" => from_value(v).map(|mut f: Function| {
-				sanitize_name(&mut f.name);
-				Operation::Function(f)
-			}),
-			"event" => from_value(v).map(|mut e: Event| {
-				sanitize_name(&mut e.name);
-				Operation::Event(e)
-			}),
-			"fallback" => Ok(Operation::Fallback),
-			"receive" => Ok(Operation::Receive),
-			other => Err(SerdeError::custom(format!("Invalid operation type {}.", other))),
-		};
-		result.map_err(|e| D::Error::custom(e.to_string()))
-	}
 }
 
 #[cfg(test)]

--- a/ethabi/src/operation.rs
+++ b/ethabi/src/operation.rs
@@ -35,10 +35,11 @@ pub enum Operation {
 #[cfg(test)]
 mod tests {
 	use super::Operation;
+	use crate::tests::assert_ser_de;
 	use crate::{Event, EventParam, Function, Param, ParamType, StateMutability};
 
 	#[test]
-	fn deserialize_operation() {
+	fn operation() {
 		let s = r#"{
 			"type":"function",
 			"inputs": [{
@@ -60,10 +61,12 @@ mod tests {
 			state_mutability: StateMutability::NonPayable,
 		};
 		assert_eq!(deserialized, Operation::Function(function));
+
+		assert_ser_de(&deserialized);
 	}
 
 	#[test]
-	fn deserialize_event_operation_with_tuple_array_input() {
+	fn event_operation_with_tuple_array_input() {
 		let s = r#"{
 			"type":"event",
 			"inputs": [
@@ -122,31 +125,35 @@ mod tests {
 				anonymous: false,
 			})
 		);
+
+		assert_ser_de(&deserialized);
 	}
 
 	#[test]
-	fn deserialize_sanitize_function_name() {
+	fn sanitize_function_name() {
 		fn test_sanitize_function_name(name: &str, expected: &str) {
 			let s = format!(
 				r#"{{
-				"type":"function",
-				"inputs": [{{
-					"name":"a",
-					"type":"address"
-				}}],
-				"name":"{}",
-				"outputs": []
-			}}"#,
+					"type":"function",
+					"inputs": [{{
+						"name":"a",
+						"type":"address"
+					}}],
+					"name":"{}",
+					"outputs": []
+				}}"#,
 				name
 			);
 
 			let deserialized: Operation = serde_json::from_str(&s).unwrap();
-			let function = match deserialized {
+			let function = match &deserialized {
 				Operation::Function(f) => f,
 				_ => panic!("expected funciton"),
 			};
 
 			assert_eq!(function.name, expected);
+
+			assert_ser_de(&deserialized);
 		}
 
 		test_sanitize_function_name("foo", "foo");
@@ -156,20 +163,20 @@ mod tests {
 	}
 
 	#[test]
-	fn deserialize_sanitize_event_name() {
+	fn sanitize_event_name() {
 		fn test_sanitize_event_name(name: &str, expected: &str) {
 			let s = format!(
 				r#"{{
-				"type":"event",
-					"inputs": [{{
-						"name":"a",
-						"type":"address",
-						"indexed":true
-					}}],
-					"name":"{}",
-					"outputs": [],
-					"anonymous": false
-			}}"#,
+					"type":"event",
+						"inputs": [{{
+							"name":"a",
+							"type":"address",
+							"indexed":true
+						}}],
+						"name":"{}",
+						"outputs": [],
+						"anonymous": false
+				}}"#,
 				name
 			);
 
@@ -180,6 +187,8 @@ mod tests {
 			};
 
 			assert_eq!(event.name, expected);
+
+			assert_ser_de(&Operation::Event(event));
 		}
 
 		test_sanitize_event_name("foo", "foo");

--- a/ethabi/src/operation.rs
+++ b/ethabi/src/operation.rs
@@ -35,8 +35,7 @@ pub enum Operation {
 #[cfg(test)]
 mod tests {
 	use super::Operation;
-	use crate::tests::assert_ser_de;
-	use crate::{Event, EventParam, Function, Param, ParamType, StateMutability};
+	use crate::{tests::assert_ser_de, Event, EventParam, Function, Param, ParamType, StateMutability};
 
 	#[test]
 	fn operation() {

--- a/ethabi/src/param.rs
+++ b/ethabi/src/param.rs
@@ -168,9 +168,10 @@ impl Serialize for SerializeableParam<'_> {
 #[cfg(test)]
 mod tests {
 	use crate::{Param, ParamType};
+	use crate::tests::{assert_json_eq, assert_ser_de};
 
 	#[test]
-	fn param_deserialization() {
+	fn param_simple() {
 		let s = r#"{
 			"name": "foo",
 			"type": "address"
@@ -179,10 +180,45 @@ mod tests {
 		let deserialized: Param = serde_json::from_str(s).unwrap();
 
 		assert_eq!(deserialized, Param { name: "foo".to_owned(), kind: ParamType::Address });
+
+		assert_json_eq(s, serde_json::to_string(&deserialized).unwrap().as_str());
 	}
 
 	#[test]
-	fn param_tuple_deserialization() {
+	fn param_tuple() {
+		let s = r#"{
+			"name": "foo",
+			"type": "tuple",
+			"components": [
+				{
+					"type": "uint48"
+				},
+				{
+					"type": "tuple",
+					"components": [
+						{
+							"type": "address"
+						}
+					]
+				}
+			]
+		}"#;
+
+		let deserialized: Param = serde_json::from_str(s).unwrap();
+
+		assert_eq!(
+			deserialized,
+			Param {
+				name: "foo".to_owned(),
+				kind: ParamType::Tuple(vec![ParamType::Uint(48), ParamType::Tuple(vec![ParamType::Address])]),
+			}
+		);
+
+		assert_json_eq(s, serde_json::to_string(&deserialized).unwrap().as_str());
+	}
+
+	#[test]
+	fn param_tuple_named() {
 		let s = r#"{
 			"name": "foo",
 			"type": "tuple",
@@ -213,24 +249,23 @@ mod tests {
 				kind: ParamType::Tuple(vec![ParamType::Uint(48), ParamType::Tuple(vec![ParamType::Address])]),
 			}
 		);
+
+		assert_ser_de(&deserialized);
 	}
 
 	#[test]
-	fn param_tuple_array_deserialization() {
+	fn param_tuple_array() {
 		let s = r#"{
 			"name": "foo",
 			"type": "tuple[]",
 			"components": [
 				{
-					"name": "amount",
 					"type": "uint48"
 				},
 				{
-					"name": "to",
 					"type": "address"
 				},
 				{
-					"name": "from",
 					"type": "address"
 				}
 			]
@@ -249,20 +284,20 @@ mod tests {
 				]))),
 			}
 		);
+
+		assert_json_eq(s, serde_json::to_string(&deserialized).unwrap().as_str());
 	}
 
 	#[test]
-	fn param_array_of_array_of_tuple_deserialization() {
+	fn param_array_of_array_of_tuple() {
 		let s = r#"{
 			"name": "foo",
 			"type": "tuple[][]",
 			"components": [
 				{
-					"name": "u0",
 					"type": "uint8"
 				},
 				{
-					"name": "u1",
 					"type": "uint16"
 				}
 			]
@@ -279,24 +314,23 @@ mod tests {
 				]))))),
 			}
 		);
+
+		assert_json_eq(s, serde_json::to_string(&deserialized).unwrap().as_str());
 	}
 
 	#[test]
-	fn param_tuple_fixed_array_deserialization() {
+	fn param_tuple_fixed_array() {
 		let s = r#"{
 			"name": "foo",
 			"type": "tuple[2]",
 			"components": [
 				{
-					"name": "amount",
 					"type": "uint48"
 				},
 				{
-					"name": "to",
 					"type": "address"
 				},
 				{
-					"name": "from",
 					"type": "address"
 				}
 			]
@@ -314,30 +348,28 @@ mod tests {
 				),
 			}
 		);
+
+		assert_json_eq(s, serde_json::to_string(&deserialized).unwrap().as_str());
 	}
 
 	#[test]
-	fn param_tuple_with_nested_tuple_arrays_deserialization() {
+	fn param_tuple_with_nested_tuple_arrays() {
 		let s = r#"{
 			"name": "foo",
 			"type": "tuple",
 			"components": [
 				{
-					"name": "bar",
 					"type": "tuple[]",
 					"components": [
 						{
-							"name": "a",
 							"type": "address"
 						}
 					]
 				},
 				{
-					"name": "baz",
 					"type": "tuple[42]",
 					"components": [
 						{
-							"name": "b",
 							"type": "address"
 						}
 					]
@@ -357,7 +389,7 @@ mod tests {
 				]),
 			}
 		);
-	}
 
-	// TODO: tests!
+		assert_json_eq(s, serde_json::to_string(&deserialized).unwrap().as_str());
+	}
 }

--- a/ethabi/src/param.rs
+++ b/ethabi/src/param.rs
@@ -167,8 +167,8 @@ impl Serialize for SerializeableParam<'_> {
 
 #[cfg(test)]
 mod tests {
-	use crate::{Param, ParamType};
 	use crate::tests::{assert_json_eq, assert_ser_de};
+	use crate::{Param, ParamType};
 
 	#[test]
 	fn param_simple() {

--- a/ethabi/src/param.rs
+++ b/ethabi/src/param.rs
@@ -14,8 +14,7 @@ use serde::{
 };
 use std::fmt;
 
-use crate::param_type::Writer;
-use crate::{ParamType, TupleParam};
+use crate::{param_type::Writer, ParamType, TupleParam};
 use serde::ser::{SerializeMap, SerializeSeq};
 
 /// Function param.
@@ -167,8 +166,10 @@ impl Serialize for SerializeableParam<'_> {
 
 #[cfg(test)]
 mod tests {
-	use crate::tests::{assert_json_eq, assert_ser_de};
-	use crate::{Param, ParamType};
+	use crate::{
+		tests::{assert_json_eq, assert_ser_de},
+		Param, ParamType,
+	};
 
 	#[test]
 	fn param_simple() {

--- a/ethabi/src/param_type/writer.rs
+++ b/ethabi/src/param_type/writer.rs
@@ -14,6 +14,13 @@ pub struct Writer;
 impl Writer {
 	/// Returns string which is a formatted represenation of param.
 	pub fn write(param: &ParamType) -> String {
+		Writer::write_for_abi(param, true)
+	}
+
+	/// If `serialize_tuple_contents` is `true`, tuples will be represented
+	/// as list of inner types in parens, for example `(int256,bool)`.
+	/// If it is `false`, tuples will be represented as keyword `tuple`.
+	pub fn write_for_abi(param: &ParamType, serialize_tuple_contents: bool) -> String {
 		match *param {
 			ParamType::Address => "address".to_owned(),
 			ParamType::Bytes => "bytes".to_owned(),
@@ -22,10 +29,23 @@ impl Writer {
 			ParamType::Uint(len) => format!("uint{}", len),
 			ParamType::Bool => "bool".to_owned(),
 			ParamType::String => "string".to_owned(),
-			ParamType::FixedArray(ref param, len) => format!("{}[{}]", Writer::write(param), len),
-			ParamType::Array(ref param) => format!("{}[]", Writer::write(param)),
+			ParamType::FixedArray(ref param, len) => {
+				format!("{}[{}]", Writer::write_for_abi(param, serialize_tuple_contents), len)
+			}
+			ParamType::Array(ref param) => {
+				format!("{}[]", Writer::write_for_abi(param, serialize_tuple_contents))
+			}
 			ParamType::Tuple(ref params) => {
-				format!("({})", params.iter().map(|ref t| format!("{}", t)).collect::<Vec<String>>().join(","))
+				if serialize_tuple_contents {
+					let formatted = params
+						.iter()
+						.map(|t| Writer::write_for_abi(t, serialize_tuple_contents))
+						.collect::<Vec<String>>()
+						.join(",");
+					format!("({})", formatted)
+				} else {
+					"tuple".to_owned()
+				}
 			}
 		}
 	}
@@ -57,6 +77,14 @@ mod tests {
 				ParamType::FixedBytes(32),
 			])))),
 			"((int256,uint256)[],bytes32)[]".to_owned()
+		);
+
+		assert_eq!(
+			Writer::write_for_abi(&ParamType::Array(Box::new(ParamType::Tuple(vec![
+				ParamType::Array(Box::new(ParamType::Int(256))),
+				ParamType::FixedBytes(32),
+			]))), false),
+			"tuple[]".to_owned()
 		);
 	}
 }

--- a/ethabi/src/param_type/writer.rs
+++ b/ethabi/src/param_type/writer.rs
@@ -80,10 +80,13 @@ mod tests {
 		);
 
 		assert_eq!(
-			Writer::write_for_abi(&ParamType::Array(Box::new(ParamType::Tuple(vec![
-				ParamType::Array(Box::new(ParamType::Int(256))),
-				ParamType::FixedBytes(32),
-			]))), false),
+			Writer::write_for_abi(
+				&ParamType::Array(Box::new(ParamType::Tuple(vec![
+					ParamType::Array(Box::new(ParamType::Int(256))),
+					ParamType::FixedBytes(32),
+				]))),
+				false
+			),
 			"tuple[]".to_owned()
 		);
 	}

--- a/ethabi/src/state_mutability.rs
+++ b/ethabi/src/state_mutability.rs
@@ -25,8 +25,8 @@ impl Default for StateMutability {
 
 #[cfg(test)]
 mod test {
-	use crate::StateMutability;
 	use crate::tests::assert_json_eq;
+	use crate::StateMutability;
 
 	#[test]
 	fn state_mutability() {
@@ -43,12 +43,7 @@ mod test {
 
 		assert_eq!(
 			deserialized,
-			vec![
-				StateMutability::Pure,
-				StateMutability::View,
-				StateMutability::NonPayable,
-				StateMutability::Payable,
-			]
+			vec![StateMutability::Pure, StateMutability::View, StateMutability::NonPayable, StateMutability::Payable,]
 		);
 
 		assert_json_eq(json, &serde_json::to_string(&deserialized).unwrap());

--- a/ethabi/src/state_mutability.rs
+++ b/ethabi/src/state_mutability.rs
@@ -1,57 +1,24 @@
-use serde::{
-	de::{Error, Visitor},
-	Deserialize, Deserializer,
-};
-use std::fmt;
+use serde::{Deserialize, Serialize};
 
 /// Whether a function modifies or reads blockchain state
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StateMutability {
 	/// Specified not to read blockchain state
+	#[serde(rename = "pure")]
 	Pure,
 	/// Specified to not modify the blockchain state
+	#[serde(rename = "view")]
 	View,
 	/// Function does not accept Ether - the default
+	#[serde(rename = "payable")]
 	NonPayable,
 	/// Function accepts Ether
+	#[serde(rename = "nonpayable")]
 	Payable,
 }
 
 impl Default for StateMutability {
 	fn default() -> Self {
 		Self::NonPayable
-	}
-}
-
-impl<'a> Deserialize<'a> for StateMutability {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: Deserializer<'a>,
-	{
-		deserializer.deserialize_any(StateMutabilityVisitor)
-	}
-}
-
-struct StateMutabilityVisitor;
-
-impl<'a> Visitor<'a> for StateMutabilityVisitor {
-	type Value = StateMutability;
-
-	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-		write!(formatter, "the string 'pure', 'view', 'payable', or 'nonpayable'")
-	}
-
-	fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-	where
-		E: Error,
-	{
-		use StateMutability::*;
-		Ok(match v {
-			"pure" => Pure,
-			"view" => View,
-			"payable" => Payable,
-			"nonpayable" => NonPayable,
-			_ => return Err(Error::unknown_variant(v, &["pure", "view", "payable", "nonpayable"])),
-		})
 	}
 }

--- a/ethabi/src/state_mutability.rs
+++ b/ethabi/src/state_mutability.rs
@@ -10,15 +10,47 @@ pub enum StateMutability {
 	#[serde(rename = "view")]
 	View,
 	/// Function does not accept Ether - the default
-	#[serde(rename = "payable")]
+	#[serde(rename = "nonpayable")]
 	NonPayable,
 	/// Function accepts Ether
-	#[serde(rename = "nonpayable")]
+	#[serde(rename = "payable")]
 	Payable,
 }
 
 impl Default for StateMutability {
 	fn default() -> Self {
 		Self::NonPayable
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use crate::StateMutability;
+	use crate::tests::assert_json_eq;
+
+	#[test]
+	fn state_mutability() {
+		let json = r#"
+			[
+				"pure",
+				"view",
+				"nonpayable",
+				"payable"
+			]
+		"#;
+
+		let deserialized: Vec<StateMutability> = serde_json::from_str(json).unwrap();
+
+		assert_eq!(
+			deserialized,
+			vec![
+				StateMutability::Pure,
+				StateMutability::View,
+				StateMutability::NonPayable,
+				StateMutability::Payable,
+			]
+		);
+
+		assert_json_eq(json, &serde_json::to_string(&deserialized).unwrap());
 	}
 }

--- a/ethabi/src/state_mutability.rs
+++ b/ethabi/src/state_mutability.rs
@@ -25,8 +25,7 @@ impl Default for StateMutability {
 
 #[cfg(test)]
 mod test {
-	use crate::tests::assert_json_eq;
-	use crate::StateMutability;
+	use crate::{tests::assert_json_eq, StateMutability};
 
 	#[test]
 	fn state_mutability() {

--- a/ethabi/src/tests.rs
+++ b/ethabi/src/tests.rs
@@ -9,6 +9,25 @@
 use crate::{decode, encode, ParamType, Token};
 use hex_literal::hex;
 
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fmt::Debug;
+
+pub(crate) fn assert_json_eq(left: &str, right: &str) {
+	let left: Value = serde_json::from_str(left).unwrap();
+	let right: Value = serde_json::from_str(right).unwrap();
+	assert_eq!(left, right);
+}
+
+pub(crate) fn assert_ser_de<T>(canon: &T)
+where
+	T: Serialize + for <'a> Deserialize<'a> + PartialEq + Debug,
+{
+	let ser = serde_json::to_string(canon).unwrap();
+	let de = serde_json::from_str(&ser).unwrap();
+	assert_eq!(canon, &de);
+}
+
 macro_rules! test_encode_decode {
 	(name: $name:tt, types: $types:expr, tokens: $tokens:expr, data: $data:tt) => {
 		paste::item! {

--- a/ethabi/src/tests.rs
+++ b/ethabi/src/tests.rs
@@ -21,7 +21,7 @@ pub(crate) fn assert_json_eq(left: &str, right: &str) {
 
 pub(crate) fn assert_ser_de<T>(canon: &T)
 where
-	T: Serialize + for <'a> Deserialize<'a> + PartialEq + Debug,
+	T: Serialize + for<'a> Deserialize<'a> + PartialEq + Debug,
 {
 	let ser = serde_json::to_string(canon).unwrap();
 	let de = serde_json::from_str(&ser).unwrap();

--- a/ethabi/src/tuple_param.rs
+++ b/ethabi/src/tuple_param.rs
@@ -8,11 +8,10 @@
 
 //! Tuple param type.
 
-use crate::param_type::Writer;
-use crate::ParamType;
-use serde::ser::SerializeMap;
+use crate::{param_type::Writer, ParamType};
 use serde::{
 	de::{Error, MapAccess, Visitor},
+	ser::SerializeMap,
 	Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::fmt;
@@ -104,8 +103,10 @@ impl Serialize for TupleParam {
 
 #[cfg(test)]
 mod tests {
-	use crate::tests::{assert_json_eq, assert_ser_de};
-	use crate::{ParamType, TupleParam};
+	use crate::{
+		tests::{assert_json_eq, assert_ser_de},
+		ParamType, TupleParam,
+	};
 
 	#[test]
 	fn param_simple() {

--- a/ethabi/src/util.rs
+++ b/ethabi/src/util.rs
@@ -17,6 +17,26 @@ pub fn pad_u32(value: u32) -> Word {
 	padded
 }
 
+// This is a workaround to support non-spec compliant function and event names,
+// see: https://github.com/paritytech/parity/issues/4122
+pub(crate) mod sanitize_name {
+	use serde::{Deserializer, Deserialize};
+
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<String, D::Error>
+		where D: Deserializer<'de>
+	{
+		let mut name = String::deserialize(deserializer)?;
+		sanitize_name(&mut name);
+		Ok(name)
+	}
+
+	fn sanitize_name(name: &mut String) {
+		if let Some(i) = name.find('(') {
+			name.truncate(i);
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::pad_u32;

--- a/ethabi/src/util.rs
+++ b/ethabi/src/util.rs
@@ -20,10 +20,11 @@ pub fn pad_u32(value: u32) -> Word {
 // This is a workaround to support non-spec compliant function and event names,
 // see: https://github.com/paritytech/parity/issues/4122
 pub(crate) mod sanitize_name {
-	use serde::{Deserializer, Deserialize};
+	use serde::{Deserialize, Deserializer};
 
 	pub fn deserialize<'de, D>(deserializer: D) -> Result<String, D::Error>
-		where D: Deserializer<'de>
+	where
+		D: Deserializer<'de>,
 	{
 		let mut name = String::deserialize(deserializer)?;
 		sanitize_name(&mut name);


### PR DESCRIPTION
Implement serialization for `contract::Contract` struct.

This is required for [gnosis/ethcontract-rs/170](https://github.com/gnosis/ethcontract-rs/issues/170).