### PR TITLE
Non-Standardized Supporting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,10 +41,25 @@ jobs:
 
       - uses: actions-rs/cargo@v1
         with:
+          command: check
+          args: --all --all-targets --no-default-features
+
+      - uses: actions-rs/cargo@v1
+        with:
           command: test
           args: --all --all-targets --all-features
 
       - uses: actions-rs/cargo@v1
         with:
+          command: test
+          args: --all --all-targets --no-default-features
+
+      - uses: actions-rs/cargo@v1
+        with:
           command: clippy
           args: --all --all-targets --all-features -- -D warnings
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all --all-targets --no-default-features -- -D warnings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,18 +41,13 @@ jobs:
 
       - uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: build
           args: --all --all-targets --no-default-features
 
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all --all-targets --all-features
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --all-targets --no-default-features
 
       - uses: actions-rs/cargo@v1
         with:

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -27,14 +27,21 @@ hex-literal = "0.3"
 paste = "1"
 
 [features]
-default = ["std"]
+default = [
+	"std",
+	"full-serde"
+]
 std = [
 	"anyhow/std",
 	"hex/std",
-	"serde",
-	"serde_json",
 	"sha3/std",
 	"ethereum-types/std",
 	"thiserror",
 	"uint/std",
+]
+
+# To enable custom `Reader` and `serde` features support
+full-serde = [
+	"serde",
+	"serde_json",
 ]

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -13,14 +13,14 @@ description = "Easy to use conversion of ethereum contract calls to bytecode."
 edition = "2018"
 
 [dependencies]
-anyhow = { version = "1", default-features = false }
+anyhow = { version = "1", optional = true }
 hex = { version = "0.4", default-features = false, features = ["alloc"]}
 serde = { version = "1.0", optional =  true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 sha3 = { version = "0.9", default-features = false }
 ethereum-types = { version = "0.11.0", default-features = false }
 thiserror = { version = "1", optional = true }
-uint = { version = "0.9.0", default-features = false }
+uint = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"
@@ -42,6 +42,8 @@ std = [
 
 # To enable custom `Reader`/`Tokenizer` and `serde` features support
 full-serde = [
+	"anyhow",
 	"serde",
 	"serde_json",
+	"uint",
 ]

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -28,7 +28,8 @@ paste = "1"
 
 [features]
 default = [
-	"full-serde"
+	"std",
+	"full-serde",
 ]
 std = [
 	"anyhow/std",

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
-hex = { version = "0.4", default-features = false }
+hex = { version = "0.4", default-features = false, features = ["alloc"]}
 serde = { version = "1.0", optional =  true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 sha3 = { version = "0.9", default-features = false }
@@ -40,7 +40,7 @@ std = [
 	"uint/std",
 ]
 
-# To enable custom `Reader` and `serde` features support
+# To enable custom `Reader`/`Tokenizer` and `serde` features support
 full-serde = [
 	"serde",
 	"serde_json",

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -28,7 +28,6 @@ paste = "1"
 
 [features]
 default = [
-	"std",
 	"full-serde"
 ]
 std = [
@@ -42,6 +41,7 @@ std = [
 
 # To enable custom `Reader`/`Tokenizer` and `serde` features support
 full-serde = [
+	"std",
 	"anyhow",
 	"serde",
 	"serde_json",

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -13,15 +13,28 @@ description = "Easy to use conversion of ethereum contract calls to bytecode."
 edition = "2018"
 
 [dependencies]
-anyhow = "1"
-hex = "0.4"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-sha3 = "0.9"
-ethereum-types = "0.11.0"
-thiserror = "1"
-uint = "0.9.0"
+anyhow = { version = "1", default-features = false }
+hex = { version = "0.4", default-features = false }
+serde = { version = "1.0", optional =  true, features = ["derive"] }
+serde_json = { version = "1.0", optional = true }
+sha3 = { version = "0.9", default-features = false }
+ethereum-types = { version = "0.11.0", default-features = false }
+thiserror = { version = "1", optional = true }
+uint = { version = "0.9.0", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"
 paste = "1"
+
+[features]
+default = ["std"]
+std = [
+	"anyhow/std",
+	"hex/std",
+	"serde",
+	"serde_json",
+	"sha3/std",
+	"ethereum-types/std",
+	"thiserror",
+	"uint/std",
+]

--- a/ethabi/src/constructor.rs
+++ b/ethabi/src/constructor.rs
@@ -7,11 +7,17 @@
 // except according to those terms.
 
 //! Contract constructor call builder.
-use crate::{encode, Bytes, Error, Param, ParamType, Result, Token};
+
+#[cfg(feature = "full-serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
+use crate::{encode, Bytes, Error, Param, ParamType, Result, Token};
+
 /// Contract constructor specification.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "full-serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Constructor {
 	/// Constructor input.
 	pub inputs: Vec<Param>,

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -6,13 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(not(feature = "std"))]
 use alloc::collections::{btree_map::Values, BTreeMap};
 #[cfg(feature = "full-serde")]
 use core::fmt;
 use core::iter::Flatten;
-#[cfg(feature = "std")]
-use std::collections::{btree_map::Values, BTreeMap};
 #[cfg(feature = "full-serde")]
 use std::io;
 

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -6,17 +6,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{errors, operation::Operation, Constructor, Error, Event, Function};
+#[cfg(not(feature = "std"))]
+use alloc::collections::{btree_map::Values, BTreeMap};
+use core::iter::Flatten;
+#[cfg(feature = "full-serde")]
+use core::{fmt, io};
+
+#[cfg(feature = "full-serde")]
 use serde::{
 	de::{SeqAccess, Visitor},
 	ser::SerializeSeq,
 	Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::{
-	collections::{hash_map::Values, HashMap},
-	fmt, io,
-	iter::Flatten,
-};
+
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
+#[cfg(feature = "full-serde")]
+use crate::operation::Operation;
+use crate::{errors, Constructor, Error, Event, Function};
 
 /// API building calls to contracts ABI.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -24,15 +31,16 @@ pub struct Contract {
 	/// Contract constructor.
 	pub constructor: Option<Constructor>,
 	/// Contract functions.
-	pub functions: HashMap<String, Vec<Function>>,
+	pub functions: BTreeMap<String, Vec<Function>>,
 	/// Contract events, maps signature to event.
-	pub events: HashMap<String, Vec<Event>>,
+	pub events: BTreeMap<String, Vec<Event>>,
 	/// Contract has receive function.
 	pub receive: bool,
 	/// Contract has fallback function.
 	pub fallback: bool,
 }
 
+#[cfg(feature = "full-serde")]
 impl<'a> Deserialize<'a> for Contract {
 	fn deserialize<D>(deserializer: D) -> Result<Contract, D::Error>
 	where
@@ -42,8 +50,10 @@ impl<'a> Deserialize<'a> for Contract {
 	}
 }
 
+#[cfg(feature = "full-serde")]
 struct ContractVisitor;
 
+#[cfg(feature = "full-serde")]
 impl<'a> Visitor<'a> for ContractVisitor {
 	type Value = Contract;
 
@@ -80,6 +90,7 @@ impl<'a> Visitor<'a> for ContractVisitor {
 	}
 }
 
+#[cfg(feature = "full-serde")]
 impl Serialize for Contract {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -137,6 +148,7 @@ impl Serialize for Contract {
 
 impl Contract {
 	/// Loads contract from json.
+	#[cfg(feature = "full-serde")]
 	pub fn load<T: io::Read>(reader: T) -> errors::Result<Self> {
 		serde_json::from_reader(reader).map_err(From::from)
 	}
@@ -200,11 +212,11 @@ impl<'a> Iterator for Events<'a> {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "full-serde"))]
 #[allow(deprecated)]
 mod test {
 	use crate::{tests::assert_ser_de, Constructor, Contract, Event, EventParam, Function, Param, ParamType};
-	use std::{collections::HashMap, iter::FromIterator};
+	use std::{collections::BTreeMap, iter::FromIterator};
 
 	#[test]
 	fn empty() {
@@ -216,8 +228,8 @@ mod test {
 			deserialized,
 			Contract {
 				constructor: None,
-				functions: HashMap::new(),
-				events: HashMap::new(),
+				functions: BTreeMap::new(),
+				events: BTreeMap::new(),
 				receive: false,
 				fallback: false,
 			}
@@ -250,8 +262,8 @@ mod test {
 				constructor: Some(Constructor {
 					inputs: vec![Param { name: "a".to_string(), kind: ParamType::Address, internal_type: None }]
 				}),
-				functions: HashMap::new(),
-				events: HashMap::new(),
+				functions: BTreeMap::new(),
+				events: BTreeMap::new(),
 				receive: false,
 				fallback: false,
 			}
@@ -295,7 +307,7 @@ mod test {
 			deserialized,
 			Contract {
 				constructor: None,
-				functions: HashMap::from_iter(vec![
+				functions: BTreeMap::from_iter(vec![
 					(
 						"foo".to_string(),
 						vec![Function {
@@ -325,7 +337,7 @@ mod test {
 						}]
 					)
 				]),
-				events: HashMap::new(),
+				events: BTreeMap::new(),
 				receive: false,
 				fallback: false,
 			}
@@ -369,7 +381,7 @@ mod test {
 			deserialized,
 			Contract {
 				constructor: None,
-				functions: HashMap::from_iter(vec![(
+				functions: BTreeMap::from_iter(vec![(
 					"foo".to_string(),
 					vec![
 						Function {
@@ -396,7 +408,7 @@ mod test {
 						}
 					]
 				)]),
-				events: HashMap::new(),
+				events: BTreeMap::new(),
 				receive: false,
 				fallback: false,
 			}
@@ -441,8 +453,8 @@ mod test {
 			deserialized,
 			Contract {
 				constructor: None,
-				functions: HashMap::new(),
-				events: HashMap::from_iter(vec![
+				functions: BTreeMap::new(),
+				events: BTreeMap::from_iter(vec![
 					(
 						"foo".to_string(),
 						vec![Event {
@@ -508,8 +520,8 @@ mod test {
 			deserialized,
 			Contract {
 				constructor: None,
-				functions: HashMap::new(),
-				events: HashMap::from_iter(vec![(
+				functions: BTreeMap::new(),
+				events: BTreeMap::from_iter(vec![(
 					"foo".to_string(),
 					vec![
 						Event {
@@ -550,8 +562,8 @@ mod test {
 			deserialized,
 			Contract {
 				constructor: None,
-				functions: HashMap::new(),
-				events: HashMap::new(),
+				functions: BTreeMap::new(),
+				events: BTreeMap::new(),
 				receive: true,
 				fallback: false,
 			}
@@ -574,8 +586,8 @@ mod test {
 			deserialized,
 			Contract {
 				constructor: None,
-				functions: HashMap::new(),
-				events: HashMap::new(),
+				functions: BTreeMap::new(),
+				events: BTreeMap::new(),
 				receive: false,
 				fallback: true,
 			}

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -8,9 +8,13 @@
 
 #[cfg(not(feature = "std"))]
 use alloc::collections::{btree_map::Values, BTreeMap};
-use core::iter::Flatten;
 #[cfg(feature = "full-serde")]
-use core::{fmt, io};
+use core::fmt;
+use core::iter::Flatten;
+#[cfg(feature = "std")]
+use std::collections::{btree_map::Values, BTreeMap};
+#[cfg(feature = "full-serde")]
+use std::io;
 
 #[cfg(feature = "full-serde")]
 use serde::{

--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -8,6 +8,8 @@
 
 //! ABI decoder.
 
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
 use crate::{Error, ParamType, Token, Word};
 
 #[derive(Debug)]
@@ -217,8 +219,11 @@ fn decode_param(param: &ParamType, data: &[u8], offset: usize) -> Result<DecodeR
 
 #[cfg(test)]
 mod tests {
-	use crate::{decode, ParamType, Token, Uint};
 	use hex_literal::hex;
+
+	#[cfg(not(feature = "std"))]
+	use crate::no_std_prelude::*;
+	use crate::{decode, ParamType, Token, Uint};
 
 	#[test]
 	fn decode_from_empty_byte_slice() {

--- a/ethabi/src/encoder.rs
+++ b/ethabi/src/encoder.rs
@@ -8,6 +8,8 @@
 
 //! ABI encoder.
 
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
 use crate::{util::pad_u32, Bytes, Token, Word};
 
 fn pad_bytes(bytes: &[u8]) -> Vec<Word> {
@@ -175,8 +177,11 @@ fn encode_token(token: &Token) -> Mediate {
 
 #[cfg(test)]
 mod tests {
-	use crate::{encode, util::pad_u32, Token};
 	use hex_literal::hex;
+
+	#[cfg(not(feature = "std"))]
+	use crate::no_std_prelude::*;
+	use crate::{encode, util::pad_u32, Token};
 
 	#[test]
 	fn encode_address() {

--- a/ethabi/src/errors.rs
+++ b/ethabi/src/errors.rs
@@ -6,46 +6,23 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use anyhow::anyhow;
-use std::{num, string};
+#[cfg(feature = "std")]
 use thiserror::Error;
 
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
+
 /// Ethabi result type
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 /// Ethabi errors
-#[derive(Debug, Error)]
+#[cfg_attr(feature = "std", derive(Error))]
+#[derive(Debug)]
 pub enum Error {
 	/// Invalid entity such as a bad function name.
-	#[error("Invalid name: {0}")]
+	#[cfg_attr(feature = "std", error("Invalid name: {0}"))]
 	InvalidName(String),
 	/// Invalid data.
-	#[error("Invalid data")]
+	#[cfg_attr(feature = "std", error("Invalid data"))]
 	InvalidData,
-	/// Serialization error.
-	#[error("Serialization error: {0}")]
-	SerdeJson(#[from] serde_json::Error),
-	/// Integer parsing error.
-	#[error("Integer parsing error: {0}")]
-	ParseInt(#[from] num::ParseIntError),
-	/// UTF-8 parsing error.
-	#[error("UTF-8 parsing error: {0}")]
-	Utf8(#[from] string::FromUtf8Error),
-	/// Hex string parsing error.
-	#[error("Hex parsing error: {0}")]
-	Hex(#[from] hex::FromHexError),
-	/// Other errors.
-	#[error("{0}")]
-	Other(#[from] anyhow::Error),
-}
-
-impl From<uint::FromDecStrErr> for Error {
-	fn from(err: uint::FromDecStrErr) -> Self {
-		use uint::FromDecStrErr::*;
-		match err {
-			InvalidCharacter => anyhow!("Uint parse error: InvalidCharacter"),
-			InvalidLength => anyhow!("Uint parse error: InvalidLength"),
-		}
-		.into()
-	}
 }

--- a/ethabi/src/errors.rs
+++ b/ethabi/src/errors.rs
@@ -6,6 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(feature = "full-serde")]
+use core::num;
+
+#[cfg(feature = "full-serde")]
+use anyhow::anyhow;
 #[cfg(feature = "std")]
 use thiserror::Error;
 
@@ -25,4 +30,32 @@ pub enum Error {
 	/// Invalid data.
 	#[cfg_attr(feature = "std", error("Invalid data"))]
 	InvalidData,
+	/// Serialization error.
+	#[cfg(feature = "full-serde")]
+	#[error("Serialization error: {0}")]
+	SerdeJson(#[from] serde_json::Error),
+	/// Integer parsing error.
+	#[cfg(feature = "full-serde")]
+	#[error("Integer parsing error: {0}")]
+	ParseInt(#[from] num::ParseIntError),
+	/// Hex string parsing error.
+	#[cfg(feature = "full-serde")]
+	#[error("Hex parsing error: {0}")]
+	Hex(#[from] hex::FromHexError),
+	/// Other errors.
+	#[cfg(feature = "full-serde")]
+	#[error("{0}")]
+	Other(#[from] anyhow::Error),
+}
+
+#[cfg(feature = "full-serde")]
+impl From<uint::FromDecStrErr> for Error {
+	fn from(err: uint::FromDecStrErr) -> Self {
+		use uint::FromDecStrErr::*;
+		match err {
+			InvalidCharacter => anyhow!("Uint parse error: InvalidCharacter"),
+			InvalidLength => anyhow!("Uint parse error: InvalidLength"),
+		}
+		.into()
+	}
 }

--- a/ethabi/src/event.rs
+++ b/ethabi/src/event.rs
@@ -8,20 +8,25 @@
 
 //! Contract event.
 
+use alloc::collections::BTreeMap;
+
+#[cfg(feature = "full-serde")]
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
-use std::collections::HashMap;
 
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
 use crate::{
 	decode, encode, signature::long_signature, Error, EventParam, Hash, Log, LogParam, ParamType, RawLog,
 	RawTopicFilter, Result, Token, Topic, TopicFilter,
 };
 
 /// Contract event.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "full-serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Event {
 	/// Event name.
-	#[serde(deserialize_with = "crate::util::sanitize_name::deserialize")]
+	#[cfg_attr(feature = "full-serde", serde(deserialize_with = "crate::util::sanitize_name::deserialize"))]
 	pub name: String,
 	/// Event input.
 	pub inputs: Vec<EventParam>,
@@ -159,7 +164,7 @@ impl Event {
 
 		let data_named_tokens = data_params.into_iter().map(|p| p.name).zip(data_tokens.into_iter());
 
-		let named_tokens = topics_named_tokens.chain(data_named_tokens).collect::<HashMap<String, Token>>();
+		let named_tokens = topics_named_tokens.chain(data_named_tokens).collect::<BTreeMap<String, Token>>();
 
 		let decoded_params = self
 			.params_names()
@@ -175,13 +180,16 @@ impl Event {
 
 #[cfg(test)]
 mod tests {
+	use hex_literal::hex;
+
+	#[cfg(not(feature = "std"))]
+	use crate::no_std_prelude::*;
 	use crate::{
 		log::{Log, RawLog},
 		signature::long_signature,
 		token::Token,
 		Event, EventParam, LogParam, ParamType,
 	};
-	use hex_literal::hex;
 
 	#[test]
 	fn test_decoding_event() {

--- a/ethabi/src/event.rs
+++ b/ethabi/src/event.rs
@@ -8,10 +8,7 @@
 
 //! Contract event.
 
-#[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap;
-#[cfg(feature = "std")]
-use std::collections::BTreeMap;
 
 #[cfg(feature = "full-serde")]
 use serde::{Deserialize, Serialize};

--- a/ethabi/src/event.rs
+++ b/ethabi/src/event.rs
@@ -8,7 +8,10 @@
 
 //! Contract event.
 
+#[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap;
+#[cfg(feature = "std")]
+use std::collections::BTreeMap;
 
 #[cfg(feature = "full-serde")]
 use serde::{Deserialize, Serialize};

--- a/ethabi/src/event_param.rs
+++ b/ethabi/src/event_param.rs
@@ -17,9 +17,9 @@ use serde::{
 	Deserialize, Deserializer, Serialize, Serializer,
 };
 
+use crate::ParamType;
 #[cfg(feature = "full-serde")]
-use crate::param_type::Writer;
-use crate::{ParamType, TupleParam};
+use crate::{param_type::Writer, TupleParam};
 
 /// Event param specification.
 #[derive(Debug, Clone, PartialEq)]

--- a/ethabi/src/event_param.rs
+++ b/ethabi/src/event_param.rs
@@ -8,13 +8,18 @@
 
 //! Event param specification.
 
-use crate::{param_type::Writer, ParamType, TupleParam};
+use std::fmt;
+
+#[cfg(feature = "full-serde")]
 use serde::{
 	de::{Error, MapAccess, Visitor},
 	ser::SerializeMap,
 	Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::fmt;
+
+#[cfg(feature = "full-serde")]
+use crate::param_type::Writer;
+use crate::{ParamType, TupleParam};
 
 /// Event param specification.
 #[derive(Debug, Clone, PartialEq)]
@@ -27,6 +32,7 @@ pub struct EventParam {
 	pub indexed: bool,
 }
 
+#[cfg(feature = "full-serde")]
 impl<'a> Deserialize<'a> for EventParam {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
@@ -36,8 +42,10 @@ impl<'a> Deserialize<'a> for EventParam {
 	}
 }
 
+#[cfg(feature = "full-serde")]
 struct EventParamVisitor;
 
+#[cfg(feature = "full-serde")]
 impl<'a> Visitor<'a> for EventParamVisitor {
 	type Value = EventParam;
 
@@ -92,6 +100,7 @@ impl<'a> Visitor<'a> for EventParamVisitor {
 	}
 }
 
+#[cfg(feature = "full-serde")]
 impl Serialize for EventParam {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -109,7 +118,7 @@ impl Serialize for EventParam {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "full-serde"))]
 mod tests {
 	use crate::{tests::assert_json_eq, EventParam, ParamType};
 

--- a/ethabi/src/event_param.rs
+++ b/ethabi/src/event_param.rs
@@ -8,7 +8,8 @@
 
 //! Event param specification.
 
-use std::fmt;
+#[cfg(feature = "full-serde")]
+use core::fmt;
 
 #[cfg(feature = "full-serde")]
 use serde::{
@@ -17,6 +18,8 @@ use serde::{
 	Deserialize, Deserializer, Serialize, Serializer,
 };
 
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
 use crate::ParamType;
 #[cfg(feature = "full-serde")]
 use crate::{param_type::Writer, TupleParam};

--- a/ethabi/src/filter.rs
+++ b/ethabi/src/filter.rs
@@ -6,10 +6,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{Hash, Token};
+use core::ops;
+
+#[cfg(feature = "full-serde")]
 use serde::{Serialize, Serializer};
+#[cfg(feature = "full-serde")]
 use serde_json::Value;
-use std::ops;
+
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
+use crate::{Hash, Token};
 
 /// Raw topic filter.
 #[derive(Debug, PartialEq, Default)]
@@ -35,6 +41,7 @@ pub struct TopicFilter {
 	pub topic3: Topic<Hash>,
 }
 
+#[cfg(feature = "full-serde")]
 impl Serialize for TopicFilter {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -114,6 +121,7 @@ impl<T> From<Topic<T>> for Vec<T> {
 	}
 }
 
+#[cfg(feature = "full-serde")]
 impl Serialize for Topic<Hash> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -150,13 +158,20 @@ impl<T> ops::Index<usize> for Topic<T> {
 
 #[cfg(test)]
 mod tests {
-	use super::{Topic, TopicFilter};
+	use super::Topic;
+	#[cfg(feature = "full-serde")]
+	use super::TopicFilter;
+	#[cfg(not(feature = "std"))]
+	use crate::no_std_prelude::*;
+	#[cfg(feature = "full-serde")]
 	use crate::Hash;
 
+	#[cfg(feature = "full-serde")]
 	fn hash(s: &'static str) -> Hash {
 		s.parse().unwrap()
 	}
 
+	#[cfg(feature = "full-serde")]
 	#[test]
 	fn test_topic_filter_serialization() {
 		let expected = r#"["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b",null,["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b","0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc"],null]"#;

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -22,7 +22,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq)]
 pub struct Function {
 	/// Function name.
-	#[cfg_attr(features = "full-serde", serde(deserialize_with = "crate::util::sanitize_name::deserialize"))]
+	#[cfg_attr(feature = "full-serde", serde(deserialize_with = "crate::util::sanitize_name::deserialize"))]
 	pub name: String,
 	/// Function input.
 	pub inputs: Vec<Param>,

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -8,18 +8,21 @@
 
 //! Contract function call builder.
 
-use std::string::ToString;
+#[cfg(feature = "full-serde")]
+use serde::{Deserialize, Serialize};
 
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
 use crate::{
 	decode, encode, signature::short_signature, Bytes, Error, Param, ParamType, Result, StateMutability, Token,
 };
-use serde::{Deserialize, Serialize};
 
 /// Contract function specification.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "full-serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Function {
 	/// Function name.
-	#[serde(deserialize_with = "crate::util::sanitize_name::deserialize")]
+	#[cfg_attr(features = "full-serde", serde(deserialize_with = "crate::util::sanitize_name::deserialize"))]
 	pub name: String,
 	/// Function input.
 	pub inputs: Vec<Param>,
@@ -29,10 +32,10 @@ pub struct Function {
 				replaced with stateMutability. If parsing a JSON AST created with \
 				this version or later this value will always be false, which may be wrong.")]
 	/// Constant function.
-	#[serde(default)]
+	#[cfg_attr(feature = "full-serde", serde(default))]
 	pub constant: bool,
 	/// Whether the function reads or modifies blockchain state
-	#[serde(rename = "stateMutability", default)]
+	#[cfg_attr(feature = "full-serde", serde(rename = "stateMutability", default))]
 	pub state_mutability: StateMutability,
 }
 
@@ -91,8 +94,11 @@ impl Function {
 
 #[cfg(test)]
 mod tests {
-	use crate::{Function, Param, ParamType, StateMutability, Token};
 	use hex_literal::hex;
+
+	#[cfg(not(feature = "std"))]
+	use crate::no_std_prelude::*;
+	use crate::{Function, Param, ParamType, StateMutability, Token};
 
 	#[test]
 	fn test_function_encode_call() {

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -27,7 +27,7 @@ mod no_std_prelude {
 use no_std_prelude::*;
 
 mod constructor;
-// mod contract;
+mod contract;
 mod decoder;
 mod encoder;
 mod errors;
@@ -54,8 +54,8 @@ pub use ethereum_types;
 #[cfg(feature = "full-serde")]
 pub use crate::tuple_param::TupleParam;
 pub use crate::{
-		constructor::Constructor,
-	// 	contract::{Contract, Events, Functions},
+	constructor::Constructor,
+	contract::{Contract, Events, Functions},
 	decoder::decode,
 	encoder::encode,
 	errors::{Error, Result},

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -37,12 +37,12 @@ mod errors;
 // mod function;
 // mod log;
 // mod operation;
-// mod param;
+mod param;
 pub mod param_type;
 // mod signature;
 // mod state_mutability;
 // pub mod token;
-#[cfg(feature = "std")]
+#[cfg(feature = "full-serde")]
 mod tuple_param;
 mod util;
 
@@ -51,7 +51,7 @@ mod util;
 
 pub use ethereum_types;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "full-serde")]
 pub use crate::tuple_param::TupleParam;
 pub use crate::{
 	// 	constructor::Constructor,
@@ -64,7 +64,7 @@ pub use crate::{
 	// 	filter::{RawTopicFilter, Topic, TopicFilter},
 	// 	function::Function,
 	// log::{Log, LogFilter, LogParam, ParseLog, RawLog},
-	// 	param::Param,
+	param::Param,
 	param_type::ParamType,
 	// 	state_mutability::StateMutability,
 	// token::Token,

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -33,7 +33,7 @@ use no_std_prelude::*;
 mod errors;
 // mod event;
 // mod event_param;
-// mod filter;
+mod filter;
 // mod function;
 // mod log;
 // mod operation;
@@ -61,7 +61,7 @@ pub use crate::{
 	errors::{Error, Result},
 	// 	event::Event,
 	// 	event_param::EventParam,
-	// filter::{RawTopicFilter, Topic, TopicFilter},
+	filter::{RawTopicFilter, Topic, TopicFilter},
 	// 	function::Function,
 	// log::{Log, LogFilter, LogParam, ParseLog, RawLog},
 	param::Param,

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -39,7 +39,7 @@ mod errors;
 // mod operation;
 mod param;
 pub mod param_type;
-// mod signature;
+mod signature;
 // mod state_mutability;
 // pub mod token;
 #[cfg(feature = "full-serde")]

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -40,10 +40,10 @@ mod errors;
 // mod state_mutability;
 // pub mod token;
 // mod tuple_param;
-// mod util;
+mod util;
 
-#[cfg(test)]
-mod tests;
+// #[cfg(test)]
+// mod tests;
 
 pub use ethereum_types;
 

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -36,7 +36,8 @@ mod event_param;
 mod filter;
 mod function;
 // mod log;
-// mod operation;
+#[cfg(feature = "full-serde")]
+mod operation;
 mod param;
 pub mod param_type;
 mod signature;

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -41,7 +41,7 @@ mod param;
 pub mod param_type;
 mod signature;
 // mod state_mutability;
-// pub mod token;
+pub mod token;
 #[cfg(feature = "full-serde")]
 mod tuple_param;
 mod util;
@@ -61,13 +61,13 @@ pub use crate::{
 	errors::{Error, Result},
 	// 	event::Event,
 	// 	event_param::EventParam,
-	// 	filter::{RawTopicFilter, Topic, TopicFilter},
+	// filter::{RawTopicFilter, Topic, TopicFilter},
 	// 	function::Function,
 	// log::{Log, LogFilter, LogParam, ParseLog, RawLog},
 	param::Param,
 	param_type::ParamType,
 	// 	state_mutability::StateMutability,
-	// token::Token,
+	token::Token,
 };
 
 /// ABI word.

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -24,6 +24,7 @@ mod no_std_prelude {
 		vec::Vec,
 	};
 }
+#[cfg(not(feature = "std"))]
 use no_std_prelude::*;
 
 mod constructor;
@@ -47,8 +48,8 @@ pub mod token;
 mod tuple_param;
 mod util;
 
-// #[cfg(test)]
-// mod tests;
+#[cfg(test)]
+mod tests;
 
 pub use ethereum_types;
 

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -13,12 +13,15 @@
 #![warn(missing_docs)]
 
 #[cfg(not(feature = "std"))]
+#[cfg_attr(not(feature = "std"), macro_use)]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
 mod no_std_prelude {
 	pub use alloc::{
+		borrow::ToOwned,
+		boxed::Box,
 		string::{self, String},
-		vec::{self, Vec},
+		vec::Vec,
 	};
 }
 use no_std_prelude::*;
@@ -35,7 +38,7 @@ mod errors;
 // mod log;
 // mod operation;
 // mod param;
-// pub mod param_type;
+pub mod param_type;
 // mod signature;
 // mod state_mutability;
 // pub mod token;
@@ -47,7 +50,23 @@ mod util;
 
 pub use ethereum_types;
 
-pub use crate::errors::{Error, Result};
+pub use crate::{
+	// 	constructor::Constructor,
+	// 	contract::{Contract, Events, Functions},
+	// 	decoder::decode,
+	// 	encoder::encode,
+	errors::{Error, Result},
+	// 	event::Event,
+	// 	event_param::EventParam,
+	// 	filter::{RawTopicFilter, Topic, TopicFilter},
+	// 	function::Function,
+	// log::{Log, LogFilter, LogParam, ParseLog, RawLog},
+	// 	param::Param,
+	param_type::ParamType,
+	// 	state_mutability::StateMutability,
+	// token::Token,
+	// 	tuple_param::TupleParam,
+};
 
 /// ABI word.
 pub type Word = [u8; 32];

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -40,7 +40,7 @@ mod filter;
 mod param;
 pub mod param_type;
 mod signature;
-// mod state_mutability;
+mod state_mutability;
 pub mod token;
 #[cfg(feature = "full-serde")]
 mod tuple_param;
@@ -66,7 +66,7 @@ pub use crate::{
 	// log::{Log, LogFilter, LogParam, ParseLog, RawLog},
 	param::Param,
 	param_type::ParamType,
-	// 	state_mutability::StateMutability,
+	state_mutability::StateMutability,
 	token::Token,
 };
 

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -32,7 +32,7 @@ mod decoder;
 mod encoder;
 mod errors;
 // mod event;
-// mod event_param;
+mod event_param;
 mod filter;
 mod function;
 // mod log;
@@ -60,7 +60,7 @@ pub use crate::{
 	encoder::encode,
 	errors::{Error, Result},
 	// 	event::Event,
-	// 	event_param::EventParam,
+	event_param::EventParam,
 	filter::{RawTopicFilter, Topic, TopicFilter},
 	function::Function,
 	// log::{Log, LogFilter, LogParam, ParseLog, RawLog},

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -42,7 +42,8 @@ pub mod param_type;
 // mod signature;
 // mod state_mutability;
 // pub mod token;
-// mod tuple_param;
+#[cfg(feature = "std")]
+mod tuple_param;
 mod util;
 
 // #[cfg(test)]
@@ -50,6 +51,8 @@ mod util;
 
 pub use ethereum_types;
 
+#[cfg(feature = "std")]
+pub use crate::tuple_param::TupleParam;
 pub use crate::{
 	// 	constructor::Constructor,
 	// 	contract::{Contract, Events, Functions},
@@ -65,7 +68,6 @@ pub use crate::{
 	param_type::ParamType,
 	// 	state_mutability::StateMutability,
 	// token::Token,
-	// 	tuple_param::TupleParam,
 };
 
 /// ABI word.

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -34,7 +34,7 @@ mod errors;
 // mod event;
 // mod event_param;
 mod filter;
-// mod function;
+mod function;
 // mod log;
 // mod operation;
 mod param;
@@ -62,7 +62,7 @@ pub use crate::{
 	// 	event::Event,
 	// 	event_param::EventParam,
 	filter::{RawTopicFilter, Topic, TopicFilter},
-	// 	function::Function,
+	function::Function,
 	// log::{Log, LogFilter, LogParam, ParseLog, RawLog},
 	param::Param,
 	param_type::ParamType,

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -35,7 +35,7 @@ mod errors;
 mod event_param;
 mod filter;
 mod function;
-// mod log;
+mod log;
 #[cfg(feature = "full-serde")]
 mod operation;
 mod param;
@@ -64,7 +64,7 @@ pub use crate::{
 	event_param::EventParam,
 	filter::{RawTopicFilter, Topic, TopicFilter},
 	function::Function,
-	// log::{Log, LogFilter, LogParam, ParseLog, RawLog},
+	log::{Log, LogFilter, LogParam, ParseLog, RawLog},
 	param::Param,
 	param_type::ParamType,
 	state_mutability::StateMutability,

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -20,7 +20,7 @@ mod no_std_prelude {
 	pub use alloc::{
 		borrow::ToOwned,
 		boxed::Box,
-		string::{self, String},
+		string::{self, String, ToString},
 		vec::Vec,
 	};
 }
@@ -28,8 +28,8 @@ use no_std_prelude::*;
 
 // mod constructor;
 // mod contract;
-// mod decoder;
-// mod encoder;
+mod decoder;
+mod encoder;
 mod errors;
 // mod event;
 // mod event_param;
@@ -56,8 +56,8 @@ pub use crate::tuple_param::TupleParam;
 pub use crate::{
 	// 	constructor::Constructor,
 	// 	contract::{Contract, Events, Functions},
-	// 	decoder::decode,
-	// 	encoder::encode,
+	decoder::decode,
+	encoder::encode,
 	errors::{Error, Result},
 	// 	event::Event,
 	// 	event_param::EventParam,

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -12,7 +12,6 @@
 #![allow(clippy::module_inception)]
 #![warn(missing_docs)]
 
-#[cfg(not(feature = "std"))]
 #[cfg_attr(not(feature = "std"), macro_use)]
 extern crate alloc;
 #[cfg(not(feature = "std"))]

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -31,7 +31,7 @@ mod contract;
 mod decoder;
 mod encoder;
 mod errors;
-// mod event;
+mod event;
 mod event_param;
 mod filter;
 mod function;
@@ -60,7 +60,7 @@ pub use crate::{
 	decoder::decode,
 	encoder::encode,
 	errors::{Error, Result},
-	// 	event::Event,
+	event::Event,
 	event_param::EventParam,
 	filter::{RawTopicFilter, Topic, TopicFilter},
 	function::Function,

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -26,7 +26,7 @@ mod no_std_prelude {
 }
 use no_std_prelude::*;
 
-// mod constructor;
+mod constructor;
 // mod contract;
 mod decoder;
 mod encoder;
@@ -54,7 +54,7 @@ pub use ethereum_types;
 #[cfg(feature = "full-serde")]
 pub use crate::tuple_param::TupleParam;
 pub use crate::{
-	// 	constructor::Constructor,
+		constructor::Constructor,
 	// 	contract::{Contract, Events, Functions},
 	decoder::decode,
 	encoder::encode,

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -8,50 +8,46 @@
 
 //! Ethereum ABI encoding decoding library.
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::module_inception)]
 #![warn(missing_docs)]
 
-mod constructor;
-mod contract;
-mod decoder;
-mod encoder;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+mod no_std_prelude {
+	pub use alloc::{
+		string::{self, String},
+		vec::{self, Vec},
+	};
+}
+use no_std_prelude::*;
+
+// mod constructor;
+// mod contract;
+// mod decoder;
+// mod encoder;
 mod errors;
-mod event;
-mod event_param;
-mod filter;
-mod function;
-mod log;
-mod operation;
-mod param;
-pub mod param_type;
-mod signature;
-mod state_mutability;
-pub mod token;
-mod tuple_param;
-mod util;
+// mod event;
+// mod event_param;
+// mod filter;
+// mod function;
+// mod log;
+// mod operation;
+// mod param;
+// pub mod param_type;
+// mod signature;
+// mod state_mutability;
+// pub mod token;
+// mod tuple_param;
+// mod util;
 
 #[cfg(test)]
 mod tests;
 
 pub use ethereum_types;
 
-pub use crate::{
-	constructor::Constructor,
-	contract::{Contract, Events, Functions},
-	decoder::decode,
-	encoder::encode,
-	errors::{Error, Result},
-	event::Event,
-	event_param::EventParam,
-	filter::{RawTopicFilter, Topic, TopicFilter},
-	function::Function,
-	log::{Log, LogFilter, LogParam, ParseLog, RawLog},
-	param::Param,
-	param_type::ParamType,
-	state_mutability::StateMutability,
-	token::Token,
-	tuple_param::TupleParam,
-};
+pub use crate::errors::{Error, Result};
 
 /// ABI word.
 pub type Word = [u8; 32];

--- a/ethabi/src/log.rs
+++ b/ethabi/src/log.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
 use crate::{Bytes, Hash, Result, Token, TopicFilter};
 
 /// Common filtering functions that are available for any event.

--- a/ethabi/src/operation.rs
+++ b/ethabi/src/operation.rs
@@ -147,7 +147,7 @@ mod tests {
 			let deserialized: Operation = serde_json::from_str(&s).unwrap();
 			let function = match &deserialized {
 				Operation::Function(f) => f,
-				_ => panic!("expected funciton"),
+				_ => panic!("expected function"),
 			};
 
 			assert_eq!(function.name, expected);

--- a/ethabi/src/param.rs
+++ b/ethabi/src/param.rs
@@ -8,14 +8,21 @@
 
 //! Function param.
 
+#[cfg(feature = "full-serde")]
+use core::fmt;
+
+#[cfg(feature = "full-serde")]
 use serde::{
 	de::{Error, MapAccess, Visitor},
+	ser::{SerializeMap, SerializeSeq},
 	Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::fmt;
 
-use crate::{param_type::Writer, ParamType, TupleParam};
-use serde::ser::{SerializeMap, SerializeSeq};
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
+use crate::ParamType;
+#[cfg(feature = "full-serde")]
+use crate::{param_type::Writer, TupleParam};
 
 /// Function param.
 #[derive(Debug, Clone, PartialEq)]
@@ -28,6 +35,7 @@ pub struct Param {
 	pub internal_type: Option<String>,
 }
 
+#[cfg(feature = "full-serde")]
 impl<'a> Deserialize<'a> for Param {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
@@ -37,8 +45,10 @@ impl<'a> Deserialize<'a> for Param {
 	}
 }
 
+#[cfg(feature = "full-serde")]
 struct ParamVisitor;
 
+#[cfg(feature = "full-serde")]
 impl<'a> Visitor<'a> for ParamVisitor {
 	type Value = Param;
 
@@ -92,6 +102,7 @@ impl<'a> Visitor<'a> for ParamVisitor {
 	}
 }
 
+#[cfg(feature = "full-serde")]
 impl Serialize for Param {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -111,6 +122,7 @@ impl Serialize for Param {
 	}
 }
 
+#[cfg(feature = "full-serde")]
 pub(crate) fn inner_tuple_mut(mut param: &mut ParamType) -> Option<&mut Vec<ParamType>> {
 	loop {
 		match param {
@@ -122,6 +134,7 @@ pub(crate) fn inner_tuple_mut(mut param: &mut ParamType) -> Option<&mut Vec<Para
 	}
 }
 
+#[cfg(feature = "full-serde")]
 pub(crate) fn inner_tuple(mut param: &ParamType) -> Option<&Vec<ParamType>> {
 	loop {
 		match param {
@@ -133,6 +146,7 @@ pub(crate) fn inner_tuple(mut param: &ParamType) -> Option<&Vec<ParamType>> {
 	}
 }
 
+#[cfg(feature = "full-serde")]
 pub(crate) fn set_tuple_components<Error: serde::de::Error>(
 	kind: &mut ParamType,
 	components: Option<Vec<TupleParam>>,
@@ -144,8 +158,10 @@ pub(crate) fn set_tuple_components<Error: serde::de::Error>(
 	Ok(())
 }
 
+#[cfg(feature = "full-serde")]
 pub(crate) struct SerializeableParamVec<'a>(pub(crate) &'a [ParamType]);
 
+#[cfg(feature = "full-serde")]
 impl Serialize for SerializeableParamVec<'_> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -159,8 +175,10 @@ impl Serialize for SerializeableParamVec<'_> {
 	}
 }
 
+#[cfg(feature = "full-serde")]
 pub(crate) struct SerializeableParam<'a>(pub(crate) &'a ParamType);
 
+#[cfg(feature = "full-serde")]
 impl Serialize for SerializeableParam<'_> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -176,7 +194,7 @@ impl Serialize for SerializeableParam<'_> {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "full-serde"))]
 mod tests {
 	use crate::{
 		tests::{assert_json_eq, assert_ser_de},

--- a/ethabi/src/param_type/mod.rs
+++ b/ethabi/src/param_type/mod.rs
@@ -8,9 +8,16 @@
 
 //! Function and event param types.
 
+#[cfg(feature = "std")]
 mod deserialize;
-mod param_type;
-mod reader;
-mod writer;
 
-pub use self::{param_type::ParamType, reader::Reader, writer::Writer};
+mod param_type;
+pub use param_type::ParamType;
+
+#[cfg(feature = "std")]
+mod reader;
+#[cfg(feature = "std")]
+pub use reader::Reader;
+
+mod writer;
+pub use writer::Writer;

--- a/ethabi/src/param_type/mod.rs
+++ b/ethabi/src/param_type/mod.rs
@@ -8,15 +8,15 @@
 
 //! Function and event param types.
 
-#[cfg(feature = "std")]
+#[cfg(feature = "full-serde")]
 mod deserialize;
 
 mod param_type;
 pub use param_type::ParamType;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "full-serde")]
 mod reader;
-#[cfg(feature = "std")]
+#[cfg(feature = "full-serde")]
 pub use reader::Reader;
 
 mod writer;

--- a/ethabi/src/param_type/param_type.rs
+++ b/ethabi/src/param_type/param_type.rs
@@ -8,8 +8,11 @@
 
 //! Function and event param types.
 
+use core::fmt;
+
 use super::Writer;
-use std::fmt;
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
 
 /// Function and event param types.
 #[derive(Debug, Clone, PartialEq)]
@@ -67,6 +70,8 @@ impl ParamType {
 
 #[cfg(test)]
 mod tests {
+	#[cfg(not(feature = "std"))]
+	use crate::no_std_prelude::*;
 	use crate::ParamType;
 
 	#[test]

--- a/ethabi/src/param_type/writer.rs
+++ b/ethabi/src/param_type/writer.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
 use crate::ParamType;
 
 /// Output formatter for param type.
@@ -54,6 +56,8 @@ impl Writer {
 #[cfg(test)]
 mod tests {
 	use super::Writer;
+	#[cfg(not(feature = "std"))]
+	use crate::no_std_prelude::*;
 	use crate::ParamType;
 
 	#[test]

--- a/ethabi/src/signature.rs
+++ b/ethabi/src/signature.rs
@@ -6,11 +6,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use sha3::{Digest, Keccak256};
+
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
 use crate::{
 	param_type::{ParamType, Writer},
 	Hash,
 };
-use sha3::{Digest, Keccak256};
 
 pub fn short_signature(name: &str, params: &[ParamType]) -> [u8; 4] {
 	let mut result = [0u8; 4];

--- a/ethabi/src/state_mutability.rs
+++ b/ethabi/src/state_mutability.rs
@@ -1,19 +1,21 @@
+#[cfg(feature = "full-serde")]
 use serde::{Deserialize, Serialize};
 
 /// Whether a function modifies or reads blockchain state
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "full-serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum StateMutability {
 	/// Specified not to read blockchain state
-	#[serde(rename = "pure")]
+	#[cfg_attr(feature = "full-serde", serde(rename = "pure"))]
 	Pure,
 	/// Specified to not modify the blockchain state
-	#[serde(rename = "view")]
+	#[cfg_attr(feature = "full-serde", serde(rename = "view"))]
 	View,
 	/// Function does not accept Ether - the default
-	#[serde(rename = "nonpayable")]
+	#[cfg_attr(feature = "full-serde", serde(rename = "nonpayable"))]
 	NonPayable,
 	/// Function accepts Ether
-	#[serde(rename = "payable")]
+	#[cfg_attr(feature = "full-serde", serde(rename = "payable"))]
 	Payable,
 }
 
@@ -23,7 +25,7 @@ impl Default for StateMutability {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "full-serde"))]
 mod test {
 	use crate::{tests::assert_json_eq, StateMutability};
 

--- a/ethabi/src/tests.rs
+++ b/ethabi/src/tests.rs
@@ -6,19 +6,27 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{decode, encode, ParamType, Token};
+#[cfg(feature = "full-serde")]
+use core::fmt::Debug;
+
 use hex_literal::hex;
-
+#[cfg(feature = "full-serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "full-serde")]
 use serde_json::Value;
-use std::fmt::Debug;
 
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
+use crate::{decode, encode, ParamType, Token};
+
+#[cfg(feature = "full-serde")]
 pub(crate) fn assert_json_eq(left: &str, right: &str) {
 	let left: Value = serde_json::from_str(left).unwrap();
 	let right: Value = serde_json::from_str(right).unwrap();
 	assert_eq!(left, right);
 }
 
+#[cfg(feature = "full-serde")]
 pub(crate) fn assert_ser_de<T>(canon: &T)
 where
 	T: Serialize + for<'a> Deserialize<'a> + PartialEq + Debug,

--- a/ethabi/src/token/mod.rs
+++ b/ethabi/src/token/mod.rs
@@ -11,7 +11,7 @@
 #[cfg(feature = "full-serde")]
 mod lenient;
 #[cfg(feature = "full-serde")]
-pub use licenses::LenientTokenizer;
+pub use lenient::LenientTokenizer;
 
 #[cfg(feature = "full-serde")]
 mod strict;

--- a/ethabi/src/token/mod.rs
+++ b/ethabi/src/token/mod.rs
@@ -8,16 +8,27 @@
 
 //! ABI param and parsing for it.
 
+#[cfg(feature = "full-serde")]
 mod lenient;
+#[cfg(feature = "full-serde")]
+pub use licenses::LenientTokenizer;
+
+#[cfg(feature = "full-serde")]
 mod strict;
+#[cfg(feature = "full-serde")]
+pub use strict::StrictTokenizer;
+
 mod token;
+pub use token::Token;
 
-use std::cmp::Ordering::{Equal, Less};
+#[cfg(feature = "full-serde")]
+use core::cmp::Ordering::{Equal, Less};
 
-pub use self::{lenient::LenientTokenizer, strict::StrictTokenizer, token::Token};
+#[cfg(feature = "full-serde")]
 use crate::{Error, ParamType};
 
 /// This trait should be used to parse string values as tokens.
+#[cfg(feature = "full-serde")]
 pub trait Tokenizer {
 	/// Tries to parse a string as a token of given type.
 	fn tokenize(param: &ParamType, value: &str) -> Result<Token, Error> {
@@ -176,7 +187,7 @@ pub trait Tokenizer {
 	fn tokenize_int(value: &str) -> Result<[u8; 32], Error>;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "full-serde"))]
 mod test {
 	use super::{LenientTokenizer, ParamType, Tokenizer};
 	#[test]

--- a/ethabi/src/token/token.rs
+++ b/ethabi/src/token/token.rs
@@ -7,8 +7,12 @@
 // except according to those terms.
 
 //! Ethereum ABI params.
+
+use core::fmt;
+
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
 use crate::{Address, Bytes, FixedBytes, Int, ParamType, Uint};
-use std::fmt;
 
 /// Ethereum ABI params.
 #[derive(Debug, PartialEq, Clone)]
@@ -225,6 +229,8 @@ impl Token {
 
 #[cfg(test)]
 mod tests {
+	#[cfg(not(feature = "std"))]
+	use crate::no_std_prelude::*;
 	use crate::{ParamType, Token};
 
 	#[test]

--- a/ethabi/src/util.rs
+++ b/ethabi/src/util.rs
@@ -19,7 +19,7 @@ pub fn pad_u32(value: u32) -> Word {
 
 // This is a workaround to support non-spec compliant function and event names,
 // see: https://github.com/paritytech/parity/issues/4122
-#[cfg(feature = "std")]
+#[cfg(feature = "full-serde")]
 pub(crate) mod sanitize_name {
 	use serde::{Deserialize, Deserializer};
 

--- a/ethabi/src/util.rs
+++ b/ethabi/src/util.rs
@@ -19,6 +19,7 @@ pub fn pad_u32(value: u32) -> Word {
 
 // This is a workaround to support non-spec compliant function and event names,
 // see: https://github.com/paritytech/parity/issues/4122
+#[cfg(feature = "std")]
 pub(crate) mod sanitize_name {
 	use serde::{Deserialize, Deserializer};
 


### PR DESCRIPTION
I revamp my old implementation #211.

- All JSON tests were ignored under no-std. 
- `Reader`/`Tokenizer`/`serde`/`serde_json`should be enabled by `--features full-serde`.
  - I'm not sure if I should disable `Writer` in no-std, because I found it was used in `signature`.
- `Error::FromUtf8Error` removed, cause can't find any usage of it.
- All `HashMap` change to `BTreeMap` for no-std. **!!BREAKING change!!**

@sorpaas