### PR TITLE
Remove `anyhow` in crates intended to be libraries

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-anyhow = "1"
 ethabi = { path = "../ethabi", version = "15.0.0" }
 heck = "0.3.1"
 syn = { version = "1.0.13", default-features = false, features = ["derive", "parsing", "printing", "proc-macro"] }

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -13,7 +13,6 @@ description = "Easy to use conversion of ethereum contract calls to bytecode."
 edition = "2018"
 
 [dependencies]
-anyhow = { version = "1", optional = true }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", optional =  true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
@@ -33,7 +32,6 @@ default = [
 	"rlp",
 ]
 std = [
-	"anyhow/std",
 	"hex/std",
 	"sha3/std",
 	"ethereum-types/std",
@@ -44,7 +42,6 @@ std = [
 # To enable custom `Reader`/`Tokenizer` and `serde` features support
 full-serde = [
 	"std",
-	"anyhow",
 	"serde",
 	"serde_json",
 	"uint",

--- a/ethabi/src/errors.rs
+++ b/ethabi/src/errors.rs
@@ -6,16 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(feature = "full-serde")]
-use core::num;
-
-#[cfg(feature = "full-serde")]
-use anyhow::anyhow;
-#[cfg(feature = "std")]
-use thiserror::Error;
-
+use crate::no_std_prelude::Cow;
 #[cfg(not(feature = "std"))]
 use crate::no_std_prelude::*;
+#[cfg(feature = "full-serde")]
+use core::num;
+#[cfg(feature = "std")]
+use thiserror::Error;
 
 /// Ethabi result type
 pub type Result<T> = core::result::Result<T, Error>;
@@ -43,9 +40,8 @@ pub enum Error {
 	#[error("Hex parsing error: {0}")]
 	Hex(#[from] hex::FromHexError),
 	/// Other errors.
-	#[cfg(feature = "full-serde")]
-	#[error("{0}")]
-	Other(#[from] anyhow::Error),
+	#[cfg_attr(feature = "std", error("{0}"))]
+	Other(Cow<'static, str>),
 }
 
 #[cfg(feature = "full-serde")]
@@ -53,9 +49,8 @@ impl From<uint::FromDecStrErr> for Error {
 	fn from(err: uint::FromDecStrErr) -> Self {
 		use uint::FromDecStrErr::*;
 		match err {
-			InvalidCharacter => anyhow!("Uint parse error: InvalidCharacter"),
-			InvalidLength => anyhow!("Uint parse error: InvalidLength"),
+			InvalidCharacter => Self::Other(Cow::Borrowed("Uint parse error: InvalidCharacter")),
+			InvalidLength => Self::Other(Cow::Borrowed("Uint parse error: InvalidLength")),
 		}
-		.into()
 	}
 }

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -17,11 +17,15 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 mod no_std_prelude {
 	pub use alloc::{
-		borrow::ToOwned,
+		borrow::{Cow, ToOwned},
 		boxed::Box,
 		string::{self, String, ToString},
 		vec::Vec,
 	};
+}
+#[cfg(feature = "std")]
+mod no_std_prelude {
+	pub use std::borrow::Cow;
 }
 #[cfg(not(feature = "std"))]
 use no_std_prelude::*;

--- a/ethabi/src/token/lenient.rs
+++ b/ethabi/src/token/lenient.rs
@@ -11,7 +11,7 @@ use crate::{
 	token::{StrictTokenizer, Tokenizer},
 	Uint,
 };
-use anyhow::anyhow;
+use std::borrow::Cow;
 
 /// Tries to parse string as a token. Does not require string to clearly represent the value.
 pub struct LenientTokenizer;
@@ -62,12 +62,12 @@ impl Tokenizer for LenientTokenizer {
 			if abs.is_zero() {
 				return Ok(abs.into());
 			} else if abs > max + 1 {
-				return Err(anyhow!("int256 parse error: Underflow").into());
+				return Err(Error::Other(Cow::Borrowed("int256 parse error: Underflow")));
 			}
 			!abs + 1 // two's complement
 		} else {
 			if abs > max {
-				return Err(anyhow!("int256 parse error: Overflow").into());
+				return Err(Error::Other(Cow::Borrowed("int256 parse error: Overflow")));
 			}
 			abs
 		};


### PR DESCRIPTION
`anyhow` is mostly used for applications and the usage of such crate in a library brings unnecessary weight and additional compilation times.

> This library provides anyhow::Error, a trait object based error type for easy idiomatic error handling in Rust **APPLICATIONS**.