### PR TITLE
fix: enable ethereum-types/serialize on serde

### DIFF
--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -47,4 +47,5 @@ full-serde = [
 	"serde",
 	"serde_json",
 	"uint",
+	"ethereum-types/serialize",
 ]


### PR DESCRIPTION
This broke [here](https://github.com/rust-ethereum/ethabi/commit/451d029c69a1fce7c4d57cc117e985a31dc53627#diff-df544a7958726ab559ba1610fa65ee46ee426c37eeaa7b4a4bd43808fa68d4a4R16-R50)