### PR TITLE
feat: add support for solidity error type

### DIFF
--- a/derive/src/contract.rs
+++ b/derive/src/contract.rs
@@ -75,6 +75,7 @@ mod test {
 			constructor: None,
 			functions: Default::default(),
 			events: Default::default(),
+			errors: Default::default(),
 			receive: false,
 			fallback: false,
 		};

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -185,6 +185,11 @@ impl Contract {
 		self.events.get(name).into_iter().flatten().next().ok_or_else(|| Error::InvalidName(name.to_owned()))
 	}
 
+	/// Get the contract error named `name`, the first if there are multiple.
+	pub fn error(&self, name: &str) -> errors::Result<&AbiError> {
+		self.errors.get(name).into_iter().flatten().next().ok_or_else(|| Error::InvalidName(name.to_owned()))
+	}
+
 	/// Get all contract events named `name`.
 	pub fn events_by_name(&self, name: &str) -> errors::Result<&Vec<Event>> {
 		self.events.get(name).ok_or_else(|| Error::InvalidName(name.to_owned()))
@@ -195,6 +200,11 @@ impl Contract {
 		self.functions.get(name).ok_or_else(|| Error::InvalidName(name.to_owned()))
 	}
 
+	/// Get all errors named `name`.
+	pub fn errors_by_name(&self, name: &str) -> errors::Result<&Vec<AbiError>> {
+		self.errors.get(name).ok_or_else(|| Error::InvalidName(name.to_owned()))
+	}
+
 	/// Iterate over all functions of the contract in arbitrary order.
 	pub fn functions(&self) -> Functions {
 		Functions(self.functions.values().flatten())
@@ -203,6 +213,11 @@ impl Contract {
 	/// Iterate over all events of the contract in arbitrary order.
 	pub fn events(&self) -> Events {
 		Events(self.events.values().flatten())
+	}
+
+	/// Iterate over all errors of the contract in arbitrary order.
+	pub fn errors(&self) -> AbiErrors {
+		AbiErrors(self.errors.values().flatten())
 	}
 }
 
@@ -222,6 +237,17 @@ pub struct Events<'a>(Flatten<Values<'a, String, Vec<Event>>>);
 
 impl<'a> Iterator for Events<'a> {
 	type Item = &'a Event;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		self.0.next()
+	}
+}
+
+/// Contract errors iterator.
+pub struct AbiErrors<'a>(Flatten<Values<'a, String, Vec<AbiError>>>);
+
+impl<'a> Iterator for AbiErrors<'a> {
+	type Item = &'a AbiError;
 
 	fn next(&mut self) -> Option<Self::Item> {
 		self.0.next()

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -20,12 +20,11 @@ use serde::{
 	Deserialize, Deserializer, Serialize, Serializer,
 };
 
-use crate::error::Error as AbiError;
 #[cfg(not(feature = "std"))]
 use crate::no_std_prelude::*;
 #[cfg(feature = "full-serde")]
 use crate::operation::Operation;
-use crate::{errors, Constructor, Error, Event, Function};
+use crate::{error::Error as AbiError, errors, Constructor, Error, Event, Function};
 
 /// API building calls to contracts ABI.
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/ethabi/src/error.rs
+++ b/ethabi/src/error.rs
@@ -1,0 +1,59 @@
+// Copyright 2015-2020 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Contract error
+
+#[cfg(feature = "full-serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::errors;
+#[cfg(not(feature = "std"))]
+use crate::no_std_prelude::*;
+use crate::signature::short_signature;
+use crate::{decode, encode, signature::long_signature, Bytes, Hash, Param, ParamType, Result, Token};
+
+/// Contract error specification.
+#[cfg_attr(feature = "full-serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Error {
+	/// Error name.
+	#[cfg_attr(feature = "full-serde", serde(deserialize_with = "crate::util::sanitize_name::deserialize"))]
+	pub name: String,
+	/// Error input.
+	pub inputs: Vec<Param>,
+}
+
+impl Error {
+	/// Returns types of all params.
+	fn param_types(&self) -> Vec<ParamType> {
+		self.inputs.iter().map(|p| p.kind.clone()).collect()
+	}
+
+	/// Error signature
+	pub fn signature(&self) -> Hash {
+		long_signature(&self.name, &self.param_types())
+	}
+
+	/// Prepares ABI error with given input params.
+	pub fn encode(&self, tokens: &[Token]) -> Result<Bytes> {
+		let params = self.param_types();
+
+		if !Token::types_check(tokens, &params) {
+			return Err(errors::Error::InvalidData);
+		}
+
+		let signed = short_signature(&self.name, &params).to_vec();
+		let encoded = encode(tokens);
+		Ok(signed.into_iter().chain(encoded.into_iter()).collect())
+	}
+
+	/// Parses the ABI function input to a list of tokens.
+	pub fn decode(&self, data: &[u8]) -> Result<Vec<Token>> {
+		decode(&self.param_types(), data)
+	}
+}

--- a/ethabi/src/error.rs
+++ b/ethabi/src/error.rs
@@ -11,11 +11,13 @@
 #[cfg(feature = "full-serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::errors;
 #[cfg(not(feature = "std"))]
 use crate::no_std_prelude::*;
-use crate::signature::short_signature;
-use crate::{decode, encode, signature::long_signature, Bytes, Hash, Param, ParamType, Result, Token};
+use crate::{
+	decode, encode, errors,
+	signature::{long_signature, short_signature},
+	Bytes, Hash, Param, ParamType, Result, Token,
+};
 
 /// Contract error specification.
 #[cfg_attr(feature = "full-serde", derive(Serialize, Deserialize))]

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -34,6 +34,7 @@ mod constructor;
 mod contract;
 mod decoder;
 mod encoder;
+mod error;
 mod errors;
 mod event;
 mod event_param;

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -64,6 +64,7 @@ pub use crate::{
 	contract::{Contract, Events, Functions},
 	decoder::decode,
 	encoder::encode,
+	error::Error as AbiError,
 	errors::{Error, Result},
 	event::Event,
 	event_param::EventParam,

--- a/ethabi/src/operation.rs
+++ b/ethabi/src/operation.rs
@@ -8,8 +8,7 @@
 
 //! Operation type.
 
-use crate::error::Error;
-use crate::{Constructor, Event, Function};
+use crate::{error::Error, Constructor, Event, Function};
 use serde::{Deserialize, Serialize};
 
 /// Operation type.

--- a/ethabi/src/operation.rs
+++ b/ethabi/src/operation.rs
@@ -8,6 +8,7 @@
 
 //! Operation type.
 
+use crate::error::Error;
 use crate::{Constructor, Event, Function};
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +25,9 @@ pub enum Operation {
 	/// Contract event.
 	#[serde(rename = "event")]
 	Event(Event),
+	/// Contract event.
+	#[serde(rename = "error")]
+	Error(Error),
 	/// Fallback function.
 	#[serde(rename = "fallback")]
 	Fallback,


### PR DESCRIPTION
Add support for solidity error type, closes #225

following this spec

https://docs.soliditylang.org/en/v0.8.10/abi-spec.html#errors

codec is the same as functions

Added serde tests and exposed similar functions for error on the `Contract`
