### PR TITLE
Prepare for new 16.x release

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi-cli"
-version = "15.0.0"
+version = "16.0.0"
 authors = [
     "Parity Technologies <admin@parity.io>",
     "Artem Vorotnikov <artem@vorotnikov.me>",
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-ethabi = { version = "15.0.0", path = "../ethabi" }
+ethabi = { version = "16.0.0", path = "../ethabi" }
 hex = "0.4"
 sha3 = "0.9"
 structopt = "0.3"

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi-contract"
-version = "11.0.0"
+version = "16.0.0"
 authors = [
     "Parity Technologies <admin@parity.io>",
     "Artem Vorotnikov <artem@vorotnikov.me>",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi-derive"
-version = "15.0.0"
+version = "16.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 homepage = "https://github.com/paritytech/ethabi"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-ethabi = { path = "../ethabi", version = "15.0.0" }
+ethabi = { path = "../ethabi", version = "16.0.0" }
 heck = "0.3.1"
 syn = { version = "1.0.13", default-features = false, features = ["derive", "parsing", "printing", "proc-macro"] }
 quote = "1.0.2"

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi"
-version = "15.0.0"
+version = "16.0.0"
 authors = [
     "Parity Technologies <admin@parity.io>",
     "Artem Vorotnikov <artem@vorotnikov.me>",


### PR DESCRIPTION
This PR just bumps the versions in `Cargo.toml` to `v16.0.0` in preparation for a new release including Solidity error types.

cc @gakonst 