### PR TITLE
add ether units parsing to lenient uint tokenizer

### DIFF
--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -20,6 +20,7 @@ sha3 = { version = "0.9", default-features = false }
 ethereum-types = { version = "0.12.0", default-features = false }
 thiserror = { version = "1", optional = true }
 uint = { version = "0.9.0", optional = true }
+regex = { version = "1.5.4", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"
@@ -46,6 +47,7 @@ full-serde = [
 	"serde_json",
 	"uint",
 	"ethereum-types/serialize",
+	"regex"
 ]
 
 rlp = [

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -21,6 +21,7 @@ ethereum-types = { version = "0.12.0", default-features = false }
 thiserror = { version = "1", optional = true }
 uint = { version = "0.9.0", optional = true }
 regex = { version = "1.5.4", optional = true }
+once_cell = { version = "1.9.0", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"
@@ -47,7 +48,8 @@ full-serde = [
 	"serde_json",
 	"uint",
 	"ethereum-types/serialize",
-	"regex"
+	"regex",
+	"once_cell"
 ]
 
 rlp = [

--- a/ethabi/src/token/lenient.rs
+++ b/ethabi/src/token/lenient.rs
@@ -78,7 +78,7 @@ impl Tokenizer for LenientTokenizer {
 							return Err(dec_error.into());
 						}
 
-						Uint::from_dec_str(&float_n.round().to_string())
+						Uint::from_dec_str(&float_n.to_string())
 							.map_err(|_| Error::Other(Cow::Owned(original_dec_error)))?
 					}
 					None => return Err(dec_error.into()),

--- a/ethabi/src/token/lenient.rs
+++ b/ethabi/src/token/lenient.rs
@@ -14,7 +14,8 @@ use crate::{
 use std::borrow::Cow;
 
 use once_cell::sync::Lazy;
-static RE: Lazy<regex::Regex> = Lazy::new(|| regex::Regex::new(r"([0-9]+(?:\.[0-9]+)?)\s*(ether|gwei|nanoether|nano|wei)").expect("invalid regex"));
+static RE: Lazy<regex::Regex> =
+	Lazy::new(|| regex::Regex::new(r"([0-9]+(?:\.[0-9]+)?)\s*(ether|gwei|nanoether|nano|wei)").expect("invalid regex"));
 
 /// Tries to parse string as a token. Does not require string to clearly represent the value.
 pub struct LenientTokenizer;

--- a/ethabi/src/token/lenient.rs
+++ b/ethabi/src/token/lenient.rs
@@ -197,4 +197,12 @@ mod tests {
 			LenientTokenizer::tokenize(&ParamType::Uint(256), "1wei").unwrap(),
 		);
 	}
+
+	#[test]
+	fn tokenize_uint_array_ether() {
+		assert_eq!(
+			LenientTokenizer::tokenize(&ParamType::Array(Box::new(ParamType::Uint(256))), "[1ether,0.1 ether]").unwrap(),
+			Token::Array(vec![Token::Uint(Uint::from_dec_str("1000000000000000000").unwrap()),Token::Uint(Uint::from_dec_str("100000000000000000").unwrap())])
+		);
+	}
 }

--- a/ethabi/src/token/lenient.rs
+++ b/ethabi/src/token/lenient.rs
@@ -226,27 +226,14 @@ mod tests {
 
 	#[test]
 	fn tokenize_uint_invalid_units() {
-
 		let _error = Error::from(FromDecStrErr::InvalidCharacter);
 
-		assert!(matches!(
-			LenientTokenizer::tokenize(&ParamType::Uint(256), "0..1 gwei"),
-			Err(_error))
-		);
+		assert!(matches!(LenientTokenizer::tokenize(&ParamType::Uint(256), "0..1 gwei"), Err(_error)));
 
-		assert!(matches!(
-			LenientTokenizer::tokenize(&ParamType::Uint(256), "..1 gwei"),
-			Err(_error))
-		);
+		assert!(matches!(LenientTokenizer::tokenize(&ParamType::Uint(256), "..1 gwei"), Err(_error)));
 
-		assert!(matches!(
-			LenientTokenizer::tokenize(&ParamType::Uint(256), "2.1.1 gwei"),
-			Err(_error))
-		);
+		assert!(matches!(LenientTokenizer::tokenize(&ParamType::Uint(256), "2.1.1 gwei"), Err(_error)));
 
-		assert!(matches!(
-			LenientTokenizer::tokenize(&ParamType::Uint(256), ".1.1 gwei"),
-			Err(_error))
-		);
+		assert!(matches!(LenientTokenizer::tokenize(&ParamType::Uint(256), ".1.1 gwei"), Err(_error)));
 	}
 }

--- a/ethabi/src/token/lenient.rs
+++ b/ethabi/src/token/lenient.rs
@@ -57,7 +57,7 @@ impl Tokenizer for LenientTokenizer {
 			Ok(_uint) => _uint,
 			Err(dec_error) => {
 				let original_dec_error = dec_error.to_string();
-				let re = regex!(r##"([0-9]+\.{0,1}[0-9]+)\s*(ether|gwei|nano|nanoether|wei)"##);
+				let re = regex!(r##"([0-9]+(?:\.[0-9]+)?)\s*(ether|gwei|nano|nanoether|wei)"##);
 
 				match re.captures(value) {
 					Some(captures) => {

--- a/ethabi/src/token/lenient.rs
+++ b/ethabi/src/token/lenient.rs
@@ -201,8 +201,12 @@ mod tests {
 	#[test]
 	fn tokenize_uint_array_ether() {
 		assert_eq!(
-			LenientTokenizer::tokenize(&ParamType::Array(Box::new(ParamType::Uint(256))), "[1ether,0.1 ether]").unwrap(),
-			Token::Array(vec![Token::Uint(Uint::from_dec_str("1000000000000000000").unwrap()),Token::Uint(Uint::from_dec_str("100000000000000000").unwrap())])
+			LenientTokenizer::tokenize(&ParamType::Array(Box::new(ParamType::Uint(256))), "[1ether,0.1 ether]")
+				.unwrap(),
+			Token::Array(vec![
+				Token::Uint(Uint::from_dec_str("1000000000000000000").unwrap()),
+				Token::Uint(Uint::from_dec_str("100000000000000000").unwrap())
+			])
 		);
 	}
 }

--- a/ethabi/src/token/lenient.rs
+++ b/ethabi/src/token/lenient.rs
@@ -218,7 +218,7 @@ mod tests {
 		// 0.1 wei
 		assert!(matches!(LenientTokenizer::tokenize(&ParamType::Uint(256), "0.0000000000000000001ether"), Err(_error)));
 
-		// 100 ether + 0.1 wei
+		// 1 ether + 0.1 wei
 		assert!(matches!(LenientTokenizer::tokenize(&ParamType::Uint(256), "1.0000000000000000001ether"), Err(_error)));
 
 		// 1_000_000_000 ether + 0.1 wei


### PR DESCRIPTION

#### Motivation

Allowing `LenientTokenizer` to parse `uint256` with units: `ether|gwei|nano|nanoether|wei`

eg: [Foundry](https://github.com/gakonst/foundry) uses the `LenientTokenizer` to parse function arguments given by the user through its CLI. This would help out when inserting large values. 

I don't know if inserting units into this library is desirable... The reason I'm proposing the change here is for cases such as arrays : `[1ether, 1gwei]`, which would be quite troublesome to parse in higher level libraries.