### PR TITLE
fix: `function.constant` as an `Option<bool>`

### DIFF
--- a/derive/src/function.rs
+++ b/derive/src/function.rs
@@ -61,8 +61,7 @@ pub struct Function {
 	/// Function output params.
 	outputs: Outputs,
 	#[deprecated(note = "The constant attribute was removed in Solidity 0.5.0 and has been \
-				replaced with stateMutability. If parsing a JSON AST created with \
-				this version or later this value will always be false, which may be wrong.")]
+				replaced with stateMutability.")]
 	/// Constant function.
 	constant: bool,
 	/// Whether the function reads or modifies blockchain state
@@ -139,7 +138,7 @@ impl<'a> From<&'a ethabi::Function> for Function {
 				result: output_result,
 				recreate_quote: to_ethabi_param_vec(&f.outputs),
 			},
-			constant: f.constant,
+			constant: f.constant.unwrap_or_default(),
 			state_mutability: f.state_mutability,
 		}
 	}
@@ -176,7 +175,7 @@ impl Function {
 						name: #name.into(),
 						inputs: #recreate_inputs,
 						outputs: #recreate_outputs,
-						constant: #constant,
+						constant: Some(#constant),
 						state_mutability: #state_mutability
 					}
 				}
@@ -227,7 +226,7 @@ mod tests {
 			name: "empty".into(),
 			inputs: vec![],
 			outputs: vec![],
-			constant: false,
+			constant: None,
 			state_mutability: ethabi::StateMutability::Payable,
 		};
 
@@ -243,7 +242,7 @@ mod tests {
 						name: "empty".into(),
 						inputs: vec![],
 						outputs: vec![],
-						constant: false,
+						constant: Some(false),
 						state_mutability: ::ethabi::StateMutability::Payable
 					}
 				}
@@ -295,7 +294,7 @@ mod tests {
 				kind: ethabi::ParamType::Uint(256),
 				internal_type: None,
 			}],
-			constant: false,
+			constant: None,
 			state_mutability: ethabi::StateMutability::Payable,
 		};
 
@@ -319,7 +318,7 @@ mod tests {
 							kind: ethabi::ParamType::Uint(256usize),
 							internal_type: None
 						}],
-						constant: false,
+						constant: Some(false),
 						state_mutability: ::ethabi::StateMutability::Payable
 					}
 				}
@@ -381,7 +380,7 @@ mod tests {
 				ethabi::Param { name: "".into(), kind: ethabi::ParamType::Uint(256), internal_type: None },
 				ethabi::Param { name: "".into(), kind: ethabi::ParamType::String, internal_type: None },
 			],
-			constant: false,
+			constant: None,
 			state_mutability: ethabi::StateMutability::Payable,
 		};
 
@@ -413,7 +412,7 @@ mod tests {
 							kind: ethabi::ParamType::String,
 							internal_type: None
 						}],
-						constant: false,
+						constant: Some(false),
 						state_mutability: ::ethabi::StateMutability::Payable
 					}
 				}

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -366,7 +366,7 @@ mod test {
 								kind: ParamType::Address,
 								internal_type: None,
 							}],
-							constant: false,
+							constant: None,
 							state_mutability: Default::default(),
 						}]
 					),
@@ -376,7 +376,7 @@ mod test {
 							name: "bar".to_string(),
 							inputs: vec![],
 							outputs: vec![],
-							constant: false,
+							constant: None,
 							state_mutability: Default::default(),
 						}]
 					),
@@ -441,14 +441,14 @@ mod test {
 								kind: ParamType::Address,
 								internal_type: None,
 							}],
-							constant: false,
+							constant: None,
 							state_mutability: Default::default(),
 						},
 						Function {
 							name: "foo".to_string(),
 							inputs: vec![],
 							outputs: vec![],
-							constant: false,
+							constant: None,
 							state_mutability: Default::default(),
 						},
 					]

--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -633,7 +633,7 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 					},
 				],
 				outputs: vec![],
-				constant: false,
+				constant: None,
 				state_mutability: crate::StateMutability::default(),
 			}
 		};
@@ -670,7 +670,7 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 					},
 				],
 				outputs: vec![],
-				constant: false,
+				constant: None,
 				state_mutability: crate::StateMutability::default(),
 			}
 		};

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -29,11 +29,10 @@ pub struct Function {
 	/// Function output.
 	pub outputs: Vec<Param>,
 	#[deprecated(note = "The constant attribute was removed in Solidity 0.5.0 and has been \
-				replaced with stateMutability. If parsing a JSON AST created with \
-				this version or later this value will always be false, which may be wrong.")]
+				replaced with stateMutability.")]
 	/// Constant function.
 	#[cfg_attr(feature = "full-serde", serde(default))]
-	pub constant: bool,
+	pub constant: Option<bool>,
 	/// Whether the function reads or modifies blockchain state
 	#[cfg_attr(feature = "full-serde", serde(rename = "stateMutability", default))]
 	pub state_mutability: StateMutability,
@@ -116,7 +115,7 @@ mod tests {
 				Param { name: "b".to_owned(), kind: ParamType::Bool, internal_type: None },
 			],
 			outputs: vec![],
-			constant: false,
+			constant: None,
 			state_mutability: StateMutability::Payable,
 		};
 

--- a/ethabi/src/operation.rs
+++ b/ethabi/src/operation.rs
@@ -59,7 +59,7 @@ mod tests {
 			name: "foo".to_owned(),
 			inputs: vec![Param { name: "a".to_owned(), kind: ParamType::Address, internal_type: None }],
 			outputs: vec![],
-			constant: false,
+			constant: None,
 			state_mutability: StateMutability::NonPayable,
 		};
 		assert_eq!(deserialized, Operation::Function(function));


### PR DESCRIPTION
As noted in the deprecation warning, when parsing compiler output, ethabi fills in a `false`. This causes trouble in `ethers` and `foundry` by making it so compiler outputted ABIs aren't parseable by `ethers.js` due to bad `constant` settings (i.e. `false` for a `pure`).

This PR fixes that by keeping it concrete for derive, but making it optional in the main implementation. This allows us to parse json from the solc compiler correctly and pipe that out to a valid ABI json. This could be an incorrect implementation, but it seems to work