### PR TITLE
fix(reader): default to u8 for unmatched types

### DIFF
--- a/ethabi/src/param_type/reader.rs
+++ b/ethabi/src/param_type/reader.rs
@@ -159,7 +159,9 @@ impl Reader {
 			}
 			// As discussed in https://github.com/rust-ethereum/ethabi/issues/254,
 			// any type that does not fit the above corresponds to a Solidity
-			// enum, and as a result we treat it as a uint8.
+			// `enum`, and as a result we treat it as a `uint8`. This is a unique
+			// case which occurs in libraries with exported (`public`) Solidity
+			// functions with `enum` parameters.
 			_ => ParamType::Uint(8),
 		};
 

--- a/ethabi/src/param_type/reader.rs
+++ b/ethabi/src/param_type/reader.rs
@@ -157,9 +157,10 @@ impl Reader {
 				let len = s[5..].parse()?;
 				ParamType::FixedBytes(len)
 			}
-			_ => {
-				return Err(Error::InvalidName(name.to_owned()));
-			}
+			// As discussed in https://github.com/rust-ethereum/ethabi/issues/254,
+			// any type that does not fit the above corresponds to a Solidity
+			// enum, and as a result we treat it as a uint8.
+			_ => ParamType::Uint(8),
 		};
 
 		Ok(result)


### PR DESCRIPTION
closes #254 by defaulting to uint8 on the remaining cases, which as discussed in the issue should always correspond to a Solidity enum. 