### PR TITLE
Add parity-codec cargo feature.

### DIFF
--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -55,3 +55,7 @@ full-serde = [
 rlp = [
 	"ethereum-types/rlp",
 ]
+
+parity-codec = [
+	"ethereum-types/codec"
+]


### PR DESCRIPTION
This is useful if you want to use ethabi in a substrate-related project, for example abi-encoding eth contract calls on-chain. 