### PR TITLE
chore: loosen feature requirement on deser methods

### DIFF
--- a/ethabi/src/param_type/mod.rs
+++ b/ethabi/src/param_type/mod.rs
@@ -8,15 +8,13 @@
 
 //! Function and event param types.
 
-#[cfg(feature = "full-serde")]
+#[cfg(feature = "serde")]
 mod deserialize;
 
 mod param_type;
 pub use param_type::ParamType;
 
-#[cfg(feature = "full-serde")]
 mod reader;
-#[cfg(feature = "full-serde")]
 pub use reader::Reader;
 
 mod writer;


### PR DESCRIPTION
the `full-serde` feature is not really necessary here, you can deserialize just with `serde` enabled and you don't gain anything by feature gating `reader` behind full-serde