### PR TITLE
support function types in ParamType

### DIFF
--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -137,6 +137,11 @@ fn decode_param(param: &ParamType, data: &[u8], offset: usize, validate: bool) -
 			let result = DecodeResult { token: Token::Uint(slice.into()), new_offset: offset + 32 };
 			Ok(result)
 		}
+		ParamType::Function => {
+			let bytes = take_bytes(data, offset, 24, validate)?;
+			let result = DecodeResult { token: Token::FixedBytes(bytes), new_offset: offset + 32 };
+			Ok(result)
+		}
 		ParamType::Bool => {
 			let b = as_bool(&peek_32_bytes(data, offset)?)?;
 			let result = DecodeResult { token: Token::Bool(b), new_offset: offset + 32 };

--- a/ethabi/src/param_type/param_type.rs
+++ b/ethabi/src/param_type/param_type.rs
@@ -29,6 +29,8 @@ pub enum ParamType {
 	Bool,
 	/// String.
 	String,
+	/// Function.
+	Function,
 	/// Array of unknown size.
 	Array(Box<ParamType>),
 	/// Vector of bytes with fixed size.
@@ -81,6 +83,7 @@ mod tests {
 		assert_eq!(format!("{}", ParamType::FixedBytes(32)), "bytes32".to_owned());
 		assert_eq!(format!("{}", ParamType::Uint(256)), "uint256".to_owned());
 		assert_eq!(format!("{}", ParamType::Int(64)), "int64".to_owned());
+		assert_eq!(format!("{}", ParamType::Function), "function".to_owned());
 		assert_eq!(format!("{}", ParamType::Bool), "bool".to_owned());
 		assert_eq!(format!("{}", ParamType::String), "string".to_owned());
 		assert_eq!(format!("{}", ParamType::Array(Box::new(ParamType::Bool))), "bool[]".to_owned());

--- a/ethabi/src/param_type/reader.rs
+++ b/ethabi/src/param_type/reader.rs
@@ -147,6 +147,7 @@ impl Reader {
 			"int" => ParamType::Int(256),
 			"tuple" => ParamType::Tuple(vec![]),
 			"uint" => ParamType::Uint(256),
+			"function" => ParamType::Function,
 			s if s.starts_with("int") => {
 				let len = s[3..].parse().map_err(Error::ParseInt)?;
 				ParamType::Int(len)

--- a/ethabi/src/param_type/writer.rs
+++ b/ethabi/src/param_type/writer.rs
@@ -30,6 +30,7 @@ impl Writer {
 			ParamType::Int(len) => format!("int{len}"),
 			ParamType::Uint(len) => format!("uint{len}"),
 			ParamType::Bool => "bool".to_owned(),
+			ParamType::Function => "function".to_owned(),
 			ParamType::String => "string".to_owned(),
 			ParamType::FixedArray(ref param, len) => {
 				format!("{}[{len}]", Writer::write_for_abi(param, serialize_tuple_contents))

--- a/ethabi/src/token/mod.rs
+++ b/ethabi/src/token/mod.rs
@@ -49,6 +49,9 @@ pub trait Tokenizer {
 			ParamType::Array(ref p) => Self::tokenize_array(value, p).map(Token::Array),
 			ParamType::FixedArray(ref p, len) => Self::tokenize_fixed_array(value, p, len).map(Token::FixedArray),
 			ParamType::Tuple(ref p) => Self::tokenize_struct(value, p).map(Token::Tuple),
+			ParamType::Function => {
+				Self::tokenize_fixed_bytes(value.strip_prefix("0x").unwrap_or(value), 24).map(Token::FixedBytes)
+			}
 		}
 	}
 


### PR DESCRIPTION
Related to https://github.com/rust-ethereum/ethabi/issues/273. From the [argument encoding documentation](https://docs.soliditylang.org/en/v0.8.17/abi-spec.html?highlight=abi%20encoding#argument-encoding), a `function` as argument type is similar to a 24-byte array (20 bytes address + 4 bytes function selector). 