### PR TITLE
Fix #297: add name and internal type information to ParamType::Tuple

### DIFF
--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -240,7 +240,7 @@ fn decode_param(param: &ParamType, data: &[u8], offset: usize, validate: bool) -
 			let len = t.len();
 			let mut tokens = Vec::with_capacity(len);
 			for param in t {
-				let res = decode_param(param, tail, new_offset, validate)?;
+				let res = decode_param(&param.kind, tail, new_offset, validate)?;
 				new_offset = res.new_offset;
 				tokens.push(res.token);
 			}
@@ -300,9 +300,11 @@ mod tests {
 		let uint = Token::Uint([0x11u8; 32].into());
 		let tuple = Token::Tuple(vec![address1, address2, uint]);
 		let expected = vec![tuple];
-		let decoded =
-			decode(&[ParamType::Tuple(vec![ParamType::Address, ParamType::Address, ParamType::Uint(32)])], &encoded)
-				.unwrap();
+		let decoded = decode(
+			&[ParamType::Tuple(vec![ParamType::Address.into(), ParamType::Address.into(), ParamType::Uint(32).into()])],
+			&encoded,
+		)
+		.unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -322,7 +324,8 @@ mod tests {
 		let string1 = Token::String("gavofyork".to_owned());
 		let string2 = Token::String("gavofyork".to_owned());
 		let tuple = Token::Tuple(vec![string1, string2]);
-		let decoded = decode(&[ParamType::Tuple(vec![ParamType::String, ParamType::String])], &encoded).unwrap();
+		let decoded =
+			decode(&[ParamType::Tuple(vec![ParamType::String.into(), ParamType::String.into()])], &encoded).unwrap();
 		let expected = vec![tuple];
 		assert_eq!(decoded, expected);
 	}
@@ -368,14 +371,15 @@ mod tests {
 		let expected = vec![outer_tuple];
 		let decoded = decode(
 			&[ParamType::Tuple(vec![
-				ParamType::String,
-				ParamType::Bool,
-				ParamType::String,
+				ParamType::String.into(),
+				ParamType::Bool.into(),
+				ParamType::String.into(),
 				ParamType::Tuple(vec![
-					ParamType::String,
-					ParamType::String,
-					ParamType::Tuple(vec![ParamType::String, ParamType::String]),
-				]),
+					ParamType::String.into(),
+					ParamType::String.into(),
+					ParamType::Tuple(vec![ParamType::String.into(), ParamType::String.into()]).into(),
+				])
+				.into(),
 			])],
 			&encoded,
 		)
@@ -403,7 +407,12 @@ mod tests {
 		let tuple = Token::Tuple(vec![uint, string, address1, address2]);
 		let expected = vec![tuple];
 		let decoded = decode(
-			&[ParamType::Tuple(vec![ParamType::Uint(32), ParamType::String, ParamType::Address, ParamType::Address])],
+			&[ParamType::Tuple(vec![
+				ParamType::Uint(32).into(),
+				ParamType::String.into(),
+				ParamType::Address.into(),
+				ParamType::Address.into(),
+			])],
 			&encoded,
 		)
 		.unwrap();
@@ -440,7 +449,7 @@ mod tests {
 		let decoded = decode(
 			&[
 				ParamType::Address,
-				ParamType::Tuple(vec![ParamType::Bool, ParamType::String, ParamType::String]),
+				ParamType::Tuple(vec![ParamType::Bool.into(), ParamType::String.into(), ParamType::String.into()]),
 				ParamType::Address,
 				ParamType::Address,
 				ParamType::Bool,
@@ -475,7 +484,7 @@ mod tests {
 		let decoded = decode(
 			&[
 				ParamType::Address,
-				ParamType::Tuple(vec![ParamType::Address, ParamType::Bool, ParamType::Bool]),
+				ParamType::Tuple(vec![ParamType::Address.into(), ParamType::Bool.into(), ParamType::Bool.into()]),
 				ParamType::Address,
 				ParamType::Address,
 			],
@@ -654,14 +663,15 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 				inputs: vec![
 					Param {
 						name: "c".to_string(),
-						kind: Array(Box::new(Tuple(vec![Uint(256), Uint(256)]))),
+						kind: Array(Box::new(Tuple(vec![Uint(256).into(), Uint(256).into()]))),
 						internal_type: None,
 					},
 					Param {
 						name: "d".to_string(),
 						kind: Array(Box::new(Tuple(vec![
-							Uint(256),
-							Array(Box::new(Tuple(vec![Uint(256), Array(Box::new(ParamType::String))]))),
+							Uint(256).into(),
+							Array(Box::new(Tuple(vec![Uint(256).into(), Array(Box::new(ParamType::String)).into()])))
+								.into(),
 						]))),
 						internal_type: None,
 					},

--- a/ethabi/src/event.rs
+++ b/ethabi/src/event.rs
@@ -297,7 +297,7 @@ mod tests {
 			inputs: vec![
 				EventParam {
 					name: "tuple".into(),
-					kind: ParamType::Tuple(vec![ParamType::Address, ParamType::Address]),
+					kind: ParamType::Tuple(vec![ParamType::Address.into(), ParamType::Address.into()]),
 					indexed: false,
 				},
 				EventParam { name: "addr".into(), kind: ParamType::Address, indexed: true },

--- a/ethabi/src/event_param.rs
+++ b/ethabi/src/event_param.rs
@@ -169,7 +169,10 @@ mod tests {
 			deserialized,
 			EventParam {
 				name: "foo".to_owned(),
-				kind: ParamType::Tuple(vec![ParamType::Uint(48), ParamType::Tuple(vec![ParamType::Address])]),
+				kind: ParamType::Tuple(vec![
+					ParamType::Uint(48).into(),
+					ParamType::Tuple(vec![ParamType::Address.into()]).into()
+				]),
 				indexed: true,
 			}
 		);
@@ -225,16 +228,25 @@ mod tests {
 			EventParam {
 				name: "LogTaskSubmitted".to_owned(),
 				kind: ParamType::Tuple(vec![
-					ParamType::Uint(256),
-					ParamType::Address,
-					ParamType::Tuple(vec![ParamType::Address, ParamType::Address]),
-					ParamType::Uint(256),
+					ParamType::Uint(256).into(),
+					ParamType::Address.into(),
+					ParamType::Tuple(vec![ParamType::Address.into(), ParamType::Address.into()]).into(),
+					ParamType::Uint(256).into(),
 					ParamType::Array(Box::new(ParamType::Tuple(vec![
-						ParamType::Array(Box::new(ParamType::Tuple(vec![ParamType::Address, ParamType::Bytes,]))),
-						ParamType::Array(Box::new(ParamType::Tuple(vec![ParamType::Address, ParamType::Uint(256)]))),
-						ParamType::Uint(256),
-					]))),
-					ParamType::Uint(256),
+						ParamType::Array(Box::new(ParamType::Tuple(vec![
+							ParamType::Address.into(),
+							ParamType::Bytes.into(),
+						])))
+						.into(),
+						ParamType::Array(Box::new(ParamType::Tuple(vec![
+							ParamType::Address.into(),
+							ParamType::Uint(256).into()
+						])))
+						.into(),
+						ParamType::Uint(256).into(),
+					])))
+					.into(),
+					ParamType::Uint(256).into(),
 				]),
 				indexed: false,
 			}

--- a/ethabi/src/operation.rs
+++ b/ethabi/src/operation.rs
@@ -40,7 +40,7 @@ mod tests {
 	use super::Operation;
 	#[cfg(not(feature = "std"))]
 	use crate::no_std_prelude::*;
-	use crate::{tests::assert_ser_de, Event, EventParam, Function, Param, ParamType, StateMutability};
+	use crate::{tests::assert_ser_de, Event, EventParam, Function, Param, ParamType, StateMutability, TupleParam};
 
 	#[test]
 	fn operation() {
@@ -119,9 +119,21 @@ mod tests {
 					EventParam {
 						name: "b".to_owned(),
 						kind: ParamType::Array(Box::new(ParamType::Tuple(vec![
-							ParamType::Address,
-							ParamType::Uint(256),
-							ParamType::Bytes
+							TupleParam {
+								name: Some("to".into()),
+								kind: ParamType::Address,
+								internal_type: Some("address".into())
+							},
+							TupleParam {
+								name: Some("value".into()),
+								kind: ParamType::Uint(256),
+								internal_type: Some("uint256".into())
+							},
+							TupleParam {
+								name: Some("data".into()),
+								kind: ParamType::Bytes,
+								internal_type: Some("bytes".into())
+							}
 						]))),
 						indexed: false
 					},

--- a/ethabi/src/param_type/param_type.rs
+++ b/ethabi/src/param_type/param_type.rs
@@ -13,6 +13,7 @@ use core::fmt;
 use super::Writer;
 #[cfg(not(feature = "std"))]
 use crate::no_std_prelude::*;
+use crate::TupleParam;
 
 /// Function and event param types.
 #[derive(Debug, Clone, PartialEq)]
@@ -36,7 +37,7 @@ pub enum ParamType {
 	/// Array with fixed size.
 	FixedArray(Box<ParamType>, usize),
 	/// Tuple containing different types
-	Tuple(Vec<ParamType>),
+	Tuple(Vec<TupleParam>),
 }
 
 impl fmt::Display for ParamType {
@@ -62,7 +63,7 @@ impl ParamType {
 		match self {
 			ParamType::Bytes | ParamType::String | ParamType::Array(_) => true,
 			ParamType::FixedArray(elem_type, _) => elem_type.is_dynamic(),
-			ParamType::Tuple(params) => params.iter().any(|param| param.is_dynamic()),
+			ParamType::Tuple(params) => params.iter().any(|param| param.kind.is_dynamic()),
 			_ => false,
 		}
 	}

--- a/ethabi/src/param_type/writer.rs
+++ b/ethabi/src/param_type/writer.rs
@@ -41,7 +41,7 @@ impl Writer {
 				if serialize_tuple_contents {
 					let formatted = params
 						.iter()
-						.map(|t| Writer::write_for_abi(t, serialize_tuple_contents))
+						.map(|t| Writer::write_for_abi(&t.kind, serialize_tuple_contents))
 						.collect::<Vec<String>>()
 						.join(",");
 					format!("({formatted})")
@@ -77,8 +77,12 @@ mod tests {
 		);
 		assert_eq!(
 			Writer::write(&ParamType::Array(Box::new(ParamType::Tuple(vec![
-				ParamType::Array(Box::new(ParamType::Tuple(vec![ParamType::Int(256), ParamType::Uint(256)]))),
-				ParamType::FixedBytes(32),
+				ParamType::Array(Box::new(ParamType::Tuple(vec![
+					ParamType::Int(256).into(),
+					ParamType::Uint(256).into()
+				])))
+				.into(),
+				ParamType::FixedBytes(32).into(),
 			])))),
 			"((int256,uint256)[],bytes32)[]".to_owned()
 		);
@@ -86,8 +90,8 @@ mod tests {
 		assert_eq!(
 			Writer::write_for_abi(
 				&ParamType::Array(Box::new(ParamType::Tuple(vec![
-					ParamType::Array(Box::new(ParamType::Int(256))),
-					ParamType::FixedBytes(32),
+					ParamType::Array(Box::new(ParamType::Int(256))).into(),
+					ParamType::FixedBytes(32).into(),
 				]))),
 				false
 			),

--- a/ethabi/src/tests.rs
+++ b/ethabi/src/tests.rs
@@ -565,10 +565,10 @@ test_encode_decode! {
 		ParamType::Tuple(vec![
 			ParamType::Array(Box::new(ParamType::Tuple(
 				vec![
-					ParamType::Address,
-					ParamType::Uint(256)
+					ParamType::Address.into(),
+					ParamType::Uint(256).into(),
 				]
-			)))
+			))).into()
 		])
 	],
 	tokens: {

--- a/ethabi/src/token/token.rs
+++ b/ethabi/src/token/token.rs
@@ -133,7 +133,7 @@ impl Token {
 			}
 			Token::Tuple(ref tokens) => {
 				if let ParamType::Tuple(ref param_type) = *param_type {
-					tokens.iter().enumerate().all(|(i, t)| t.type_check(&param_type[i]))
+					tokens.iter().enumerate().all(|(i, t)| t.type_check(&param_type[i].kind))
 				} else {
 					false
 				}

--- a/ethabi/src/tuple_param.rs
+++ b/ethabi/src/tuple_param.rs
@@ -31,6 +31,12 @@ pub struct TupleParam {
 	pub internal_type: Option<String>,
 }
 
+impl From<ParamType> for TupleParam {
+	fn from(value: ParamType) -> Self {
+		Self { name: None, kind: value, internal_type: None }
+	}
+}
+
 impl<'a> Deserialize<'a> for TupleParam {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
@@ -202,7 +208,10 @@ mod tests {
 			deserialized,
 			TupleParam {
 				name: None,
-				kind: ParamType::Tuple(vec![ParamType::Uint(48), ParamType::Tuple(vec![ParamType::Address])]),
+				kind: ParamType::Tuple(vec![
+					ParamType::Uint(48).into(),
+					ParamType::Tuple(vec![ParamType::Address.into()]).into()
+				]),
 				internal_type: None
 			}
 		);
@@ -238,7 +247,18 @@ mod tests {
 			deserialized,
 			TupleParam {
 				name: None,
-				kind: ParamType::Tuple(vec![ParamType::Uint(48), ParamType::Tuple(vec![ParamType::Address])]),
+				kind: ParamType::Tuple(vec![
+					TupleParam { name: Some("amount".into()), kind: ParamType::Uint(48), internal_type: None },
+					TupleParam {
+						name: Some("things".into()),
+						kind: ParamType::Tuple(vec![TupleParam {
+							name: Some("baseTupleParam".into()),
+							kind: ParamType::Address,
+							internal_type: None
+						}]),
+						internal_type: None
+					}
+				]),
 				internal_type: None
 			}
 		);
@@ -270,9 +290,9 @@ mod tests {
 			TupleParam {
 				name: None,
 				kind: ParamType::Array(Box::new(ParamType::Tuple(vec![
-					ParamType::Uint(48),
-					ParamType::Address,
-					ParamType::Address
+					ParamType::Uint(48).into(),
+					ParamType::Address.into(),
+					ParamType::Address.into()
 				]))),
 				internal_type: None
 			}
@@ -301,8 +321,8 @@ mod tests {
 			TupleParam {
 				name: None,
 				kind: ParamType::Array(Box::new(ParamType::Array(Box::new(ParamType::Tuple(vec![
-					ParamType::Uint(8),
-					ParamType::Uint(16),
+					ParamType::Uint(8).into(),
+					ParamType::Uint(16).into(),
 				]))))),
 				internal_type: None
 			}
@@ -335,7 +355,11 @@ mod tests {
 			TupleParam {
 				name: None,
 				kind: ParamType::FixedArray(
-					Box::new(ParamType::Tuple(vec![ParamType::Uint(48), ParamType::Address, ParamType::Address])),
+					Box::new(ParamType::Tuple(vec![
+						ParamType::Uint(48).into(),
+						ParamType::Address.into(),
+						ParamType::Address.into()
+					])),
 					2
 				),
 				internal_type: None
@@ -376,8 +400,8 @@ mod tests {
 			TupleParam {
 				name: None,
 				kind: ParamType::Tuple(vec![
-					ParamType::Array(Box::new(ParamType::Tuple(vec![ParamType::Address]))),
-					ParamType::FixedArray(Box::new(ParamType::Tuple(vec![ParamType::Address])), 42,)
+					ParamType::Array(Box::new(ParamType::Tuple(vec![ParamType::Address.into()]))).into(),
+					ParamType::FixedArray(Box::new(ParamType::Tuple(vec![ParamType::Address.into()])), 42,).into()
 				]),
 				internal_type: None
 			}


### PR DESCRIPTION
As mentioned in #297, this PR aims for it.