### PR TITLE
Some fixes/improvements for no_std builds

### DIFF
--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -15,13 +15,16 @@ edition = "2021"
 [dependencies]
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", optional =  true, default-features = false, features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 sha3 = { version = "0.10", default-features = false }
 ethereum-types = { version = "0.14.0", default-features = false }
 thiserror = { version = "1", optional = true }
 uint = { version = "0.9.0", default-features = false, optional = true }
 regex = { version = "1.5.4", optional = true }
 once_cell = { version = "1.9.0", optional = true }
+
+[target.'cfg(not(feature = "std"))'.dependencies]
+displaydoc = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"
@@ -41,6 +44,7 @@ std = [
 	"thiserror",
 	"uint?/std",
 	"serde?/std",
+	"serde_json?/std",
 ]
 
 serde = [

--- a/ethabi/src/errors.rs
+++ b/ethabi/src/errors.rs
@@ -13,12 +13,15 @@ use crate::no_std_prelude::*;
 use core::num;
 #[cfg(feature = "std")]
 use thiserror::Error;
+#[cfg(not(feature = "std"))]
+use displaydoc::Display;
 
 /// Ethabi result type
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Ethabi errors
 #[cfg_attr(feature = "std", derive(Error))]
+#[cfg_attr(not(feature = "std"), derive(Display))]
 #[derive(Debug)]
 pub enum Error {
 	/// Invalid entity such as a bad function name.


### PR DESCRIPTION
1. Build serde_json without the `std` feature when it is not enabled in this crate
2. Provide `Display` implementation for the `Error` enum in `no_std` builds

--- 
Some context for this: I am trying to get https://github.com/gakonst/ethers-rs/ (specifically the `ethers-core`) crate to work in a `no_std` build. `ethabi` is a dependency of it, and while iterating on it I ran into the issues this PR addresses.

Thank you!